### PR TITLE
chore: 로컬 개발 환경 docker 세팅

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-README.md
 .gradle
 build/
 !gradle/wrapper/gradle-wrapper.jar
@@ -7,8 +6,8 @@ build/
 
 .DS_Store
 *.env
-mysql_data/
-
+postgres-data/
+redis-data/
 
 ### STS ###
 .apt_generated

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,0 +1,42 @@
+services:
+
+  postgres-main:
+    image: postgres:15
+    container_name: postgres-main
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+    ports:
+      - "5432:5432"
+    volumes:
+      - ./postgres-data:/var/lib/postgresql/data
+
+  postgres-test:
+    image: postgres:15
+    container_name: postgres-test
+    environment:
+      POSTGRES_DB: ${POSTGRES_TEST_DB}
+      POSTGRES_USER: ${POSTGRES_TEST_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_TEST_PASSWORD}
+    ports:
+      - "5433:5432"
+    tmpfs:
+      - /var/lib/postgresql/data
+
+
+  redis-main:
+    image: redis:7
+    container_name: redis-main
+    ports:
+      - "6379:6379"
+    command: redis-server --appendonly yes --requirepass ${REDIS_PASSWORD}
+    volumes:
+      - ./redis-data:/data
+
+  redis-test:
+    image: redis:7
+    container_name: redis-test
+    ports:
+      - "6380:6379"
+    command: redis-server --save "" --appendonly no


### PR DESCRIPTION
## 📎 Issue 번호

## ✨ 작업 내용
로컬 개발 환경 구성을 위해 Docker Compose 설정을 추가했습니다.


## 🎯 리뷰 포인트

## 📝 기타
- 실제 로컬 서버와 붙일 Postgres DB, Redis 와 테스트용 Postgres DB, Redis 컨테이너를 분리하였습니다.  
  - 공간 연산을 사용하는 특성상 H2에서는 테스트가 어려워, 
  테스트 환경에서도 운영 환경과 동일한 Postgres DB을 사용하도록 구성했습니다.
  - Redis의 경우에도 H2 와 비슷한 Embedded Redis라는게  있었는데,
 맥북OS(M1/M2/M3)에서 호환성 문제가 있다고 해서 우선 간단하게 테스트용 컨테이너를 따로 두도록 구성하였씀미다.

P.S. 환경변수 설정은 env 파일을 만들어서 각자 세팅하면 될것 같슴다

대충 요런식으로...
```
POSTGRES_DB=디비 이름
POSTGRES_USER=유저12
POSTGRES_PASSWORD=비밀번호

POSTGRES_TEST_DB=테스트 디비
POSTGRES_TEST_USER=테스트유저
POSTGRES_TEST_PASSWORD=비번

REDIS_PASSWORD=레디스 비번
```

## ✅ 테스트
- [ ] 수동 테스트 완료
- [ ] 테스트 코드 완료