### PR TITLE
fix: GameArea FK 제약 위반 방지를 위해 JPQL 벌크 삭제로 변경

### DIFF
--- a/src/main/java/com/team/cops_and_robbers/game/area/repository/GameAreaRepository.java
+++ b/src/main/java/com/team/cops_and_robbers/game/area/repository/GameAreaRepository.java
@@ -4,6 +4,7 @@ import com.team.cops_and_robbers.common.exception.ApplicationException;
 import com.team.cops_and_robbers.game.area.domain.GameArea;
 import com.team.cops_and_robbers.game.area.exception.GameAreaException;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -13,7 +14,9 @@ public interface GameAreaRepository extends JpaRepository <GameArea, Long>{
 
     Optional<GameArea> findByGameId(Long gameId);
 
-    void deleteByGameId(Long gameId);
+    @Modifying(clearAutomatically = true)
+    @Query("delete from GameArea ga where ga.game.id = :gameId")
+    void deleteByGameId(@Param("gameId") Long gameId);
 
     default GameArea getByGameId(Long gameId) {
         return findByGameId(gameId)

--- a/src/test/java/com/team/cops_and_robbers/user/presentation/UserControllerTest.java
+++ b/src/test/java/com/team/cops_and_robbers/user/presentation/UserControllerTest.java
@@ -4,11 +4,10 @@ import com.google.firebase.auth.AuthErrorCode;
 import com.google.firebase.auth.FirebaseAuthException;
 import com.team.cops_and_robbers.auth.domain.Tokens;
 import com.team.cops_and_robbers.common.ControllerTest;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.jdbc.core.JdbcTemplate;
 import com.team.cops_and_robbers.common.exception.ApplicationException;
 import com.team.cops_and_robbers.common.exception.CommonException;
 import com.team.cops_and_robbers.common.exception.ErrorResponse;
+import com.team.cops_and_robbers.common.fixture.GameAreaFixture;
 import com.team.cops_and_robbers.common.fixture.GameFixture;
 import com.team.cops_and_robbers.common.fixture.GameParticipantFixture;
 import com.team.cops_and_robbers.common.fixture.UserFixture;
@@ -16,8 +15,6 @@ import com.team.cops_and_robbers.game.game.domain.Game;
 import com.team.cops_and_robbers.game.game.domain.GameStatus;
 import com.team.cops_and_robbers.game.participant.domain.GameParticipant;
 import com.team.cops_and_robbers.game.participant.domain.Team;
-import java.sql.Timestamp;
-import java.time.LocalDateTime;
 import com.team.cops_and_robbers.user.domain.User;
 import com.team.cops_and_robbers.user.exception.UserException;
 import com.team.cops_and_robbers.user.presentation.dto.request.NicknameUpdateRequest;
@@ -29,9 +26,17 @@ import io.restassured.response.Response;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
 
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class UserControllerTest extends ControllerTest {
 
@@ -140,6 +145,7 @@ class UserControllerTest extends ControllerTest {
             String accessToken = givenAccessToken(user);
             Game game = gameRepository.save(GameFixture.WAITING_GAME());
             gameParticipantRepository.save(GameParticipantFixture.HOST_PARTICIPANT(game, user));
+            gameAreaRepository.save(GameAreaFixture.GAME_AREA(game));
             jdbcTemplate.update(
                     "UPDATE games SET created_at = ? WHERE id = ?",
                     Timestamp.valueOf(LocalDateTime.now().minusHours(25)),
@@ -159,6 +165,8 @@ class UserControllerTest extends ControllerTest {
                 softly.assertThat(extract.statusCode()).isEqualTo(200);
                 softly.assertThat(response.isParticipating()).isFalse();
                 softly.assertThat(response.participationInfo()).isNull();
+                softly.assertThat(gameParticipantRepository.countByGameId(game.getId())).isZero();
+                softly.assertThat(gameAreaRepository.findByGameId(game.getId())).isEmpty();
                 softly.assertThat(gameRepository.findById(game.getId())).isEmpty();
             });
         }


### PR DESCRIPTION
## 📎 Issue 번호
<!-- PR과 연관된 이슈의 번호를 작성해주세요.
PR 머지 시 close 되어야 하는 이슈의 경우 이슈 번호 앞에 `closed` 키워드를 붙여주세요.  
ex) `closed #2` -->

 ## ✨ 작업 내용
  - `GameAreaRepository.deleteByGameId`를 derived delete에서 JPQL 벌크 삭제로 변경                                                                                              
  - 만료 로비 삭제 통합 테스트에 GameArea / GameParticipant 삭제 검증 추가

  ## 🎯 리뷰 포인트
  **버그 원인**
  재접속 시 만료된 로비를 삭제하는 흐름에서 500 에러 발생

```
  gameParticipantRepository.deleteAllByGameId  // JPQL → 즉시 실행
  gameAreaRepository.deleteByGameId            // derived delete → SELECT + em.remove() (지연 실행)
  gameRepository.deleteByGameId               // JPQL → 즉시 실행 ← 여기서 FK 위반
```

  `gameAreaRepository.deleteByGameId`가 Spring Data JPA의 derived delete로 구현되어 있어
  `em.remove()`를 통해 삭제가 지연(deferred)되는 반면, `gameRepository.deleteByGameId`는
  JPQL로 즉시 실행되어 `game_areas`가 남아 있는 상태에서 `games`가 먼저 삭제되면서 FK 제약 위반 발생

  → `@Modifying @Query` JPQL로 변경하여 즉시 실행되도록 수정

  ## ✅ 테스트
  - [x] 테스트 코드 완료
