### PR TITLE
feat: 이용약관 관련 API 구현

### DIFF
--- a/src/main/java/com/team/cops_and_robbers/auth/presentation/AuthControllerDocs.java
+++ b/src/main/java/com/team/cops_and_robbers/auth/presentation/AuthControllerDocs.java
@@ -41,7 +41,8 @@ public interface AuthControllerDocs {
                                                     "accessToken": "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNzY4NDk1MDA1LCJleHAiOjE3Njg0OTg2MDV9...",
                                                     "refreshToken": "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNzY4NDk1MDA1LCJleHAiOjE3Njk3MDQ2MDV9..."
                                                 },
-                                                "isNewUser": false
+                                                "isNewUser": false,
+                                                "requiresAgreement": true
                                             }
                                             """
                             )
@@ -51,7 +52,7 @@ public interface AuthControllerDocs {
                     content = @Content(
                             schema = @Schema(implementation = LoginResponse.class),
                             examples = @ExampleObject(
-                                    name = "신규 회원 가입 성공 예시",
+                                    name = "신규 회원 가입 성공 예시 (신규 회원은 항상 필수 이용 약관에 동의를 하지 않은 상태를 갖는다)",
                                     value = """
                                             {
                                                 "userId": 2,
@@ -60,7 +61,8 @@ public interface AuthControllerDocs {
                                                     "accessToken": "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIyIiwiaWF0IjoxNzY4NDk1MDEwLCJleHAiOjE3Njg0OTg2MTB9...",
                                                     "refreshToken": "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIyIiwiaWF0IjoxNzY4NDk1MDEwLCJleHAiOjE3Njk3MDQ2MTB9..."
                                                 },
-                                                "isNewUser": true
+                                                "isNewUser": true,
+                                                "requiresAgreement": false
                                             }
                                             """
                             )

--- a/src/main/java/com/team/cops_and_robbers/auth/presentation/dto/response/LoginResponse.java
+++ b/src/main/java/com/team/cops_and_robbers/auth/presentation/dto/response/LoginResponse.java
@@ -12,14 +12,17 @@ public record LoginResponse(
         @Schema(description = "JWT 토큰 정보")
         Tokens tokens,
         @Schema(description = "신규 회원 여부", example = "false")
-        boolean isNewUser
+        boolean isNewUser,
+        @Schema(description = "필수 이용약관 동의 여부", example = "true")
+        boolean requiresAgreement
 ) {
     public static LoginResponse from(LoginResult result) {
         return new LoginResponse(
                 result.user().getId(),
                 result.user().getNickname(),
                 result.tokens(),
-                result.isNewUser()
+                result.isNewUser(),
+                result.user().hasAgreedRequiredTerms()
         );
     }
 }

--- a/src/main/java/com/team/cops_and_robbers/common/swagger/SwaggerConfig.java
+++ b/src/main/java/com/team/cops_and_robbers/common/swagger/SwaggerConfig.java
@@ -30,10 +30,11 @@ public class SwaggerConfig {
 
         Info info = new Info()
                 .title("👮 경찰과 도둑 API 🥷")
-                .version("1.2.0")
+                .version("2.0.0")
                 .description("""
                         ## 업데이트 항목
-                        - 도둑 위치 조회 API 추가 (GET /api/games/{gameId}/robbers/location)
+                        - 이용 약관 동의 API 추가 (POST /api/user/agreements)
+                        - 로그인 API 필수 이용약관 동의 여부 응답 필드 추가 (POST /api/auth/login)
                         """);
 
         return new OpenAPI()

--- a/src/main/java/com/team/cops_and_robbers/common/swagger/SwaggerConfig.java
+++ b/src/main/java/com/team/cops_and_robbers/common/swagger/SwaggerConfig.java
@@ -33,8 +33,9 @@ public class SwaggerConfig {
                 .version("2.0.0")
                 .description("""
                         ## 업데이트 항목
-                        - 이용 약관 동의 API 추가 (POST /api/user/agreements)
-                        - 로그인 API 필수 이용약관 동의 여부 응답 필드 추가 (POST /api/auth/login)
+                        - (신규) 이용 약관 동의 API 추가 (POST /api/user/agreements)
+                        - (신규) 이용 약관 동의 여부 조회 API 추가 (GET /api/auth/agreements)
+                        - (수정) 로그인 API 필수 이용약관 동의 여부 응답 필드 추가 (POST /api/auth/login)
                         """);
 
         return new OpenAPI()

--- a/src/main/java/com/team/cops_and_robbers/common/swagger/SwaggerConfig.java
+++ b/src/main/java/com/team/cops_and_robbers/common/swagger/SwaggerConfig.java
@@ -36,6 +36,8 @@ public class SwaggerConfig {
                         - (신규) 이용 약관 동의 API 추가 (POST /api/user/agreements)
                         - (신규) 이용 약관 동의 여부 조회 API 추가 (GET /api/auth/agreements)
                         - (수정) 로그인 API 필수 이용약관 동의 여부 응답 필드 추가 (POST /api/auth/login)
+                        - (수정) 게임 방 생성 API 호스트 필수 이용약관 동의 여부 검증 추가 (POST /api/games)
+                        - (수정) 게임 방 참여 API 유저 필수 이용약관 동의 여부 검증 추가 (POST /api/games/join)
                         """);
 
         return new OpenAPI()

--- a/src/main/java/com/team/cops_and_robbers/common/swagger/SwaggerConfig.java
+++ b/src/main/java/com/team/cops_and_robbers/common/swagger/SwaggerConfig.java
@@ -33,7 +33,7 @@ public class SwaggerConfig {
                 .version("2.0.0")
                 .description("""
                         ## 업데이트 항목
-                        - (신규) 이용 약관 동의 API 추가 (POST /api/user/agreements)
+                        - (신규) 이용 약관 동의 API 추가 (PUT /api/user/agreements)
                         - (신규) 이용 약관 동의 여부 조회 API 추가 (GET /api/auth/agreements)
                         - (수정) 로그인 API 필수 이용약관 동의 여부 응답 필드 추가 (POST /api/auth/login)
                         - (수정) 게임 방 생성 API 호스트 필수 이용약관 동의 여부 검증 추가 (POST /api/games)

--- a/src/main/java/com/team/cops_and_robbers/common/swagger/SwaggerConfig.java
+++ b/src/main/java/com/team/cops_and_robbers/common/swagger/SwaggerConfig.java
@@ -34,7 +34,7 @@ public class SwaggerConfig {
                 .description("""
                         ## 업데이트 항목
                         - (신규) 이용 약관 동의 API 추가 (PUT /api/user/agreements)
-                        - (신규) 이용 약관 동의 여부 조회 API 추가 (GET /api/auth/agreements)
+                        - (신규) 이용 약관 동의 여부 조회 API 추가 (GET /api/user/agreements)
                         - (수정) 로그인 API 필수 이용약관 동의 여부 응답 필드 추가 (POST /api/auth/login)
                         - (수정) 게임 방 생성 API 호스트 필수 이용약관 동의 여부 검증 추가 (POST /api/games)
                         - (수정) 게임 방 참여 API 유저 필수 이용약관 동의 여부 검증 추가 (POST /api/games/join)

--- a/src/main/java/com/team/cops_and_robbers/game/game/application/GameService.java
+++ b/src/main/java/com/team/cops_and_robbers/game/game/application/GameService.java
@@ -21,6 +21,7 @@ import com.team.cops_and_robbers.game.participant.repository.GameParticipantRepo
 import com.team.cops_and_robbers.play.lobby.application.LobbyEventFactory;
 import com.team.cops_and_robbers.play.lobby.domain.LobbyEvent;
 import com.team.cops_and_robbers.user.domain.User;
+import com.team.cops_and_robbers.user.exception.UserException;
 import com.team.cops_and_robbers.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.locationtech.jts.geom.Coordinate;
@@ -63,8 +64,7 @@ public class GameService {
     @Transactional
     public GameCreateResult createGame(GameCreateCommand command) {
 
-        User host = userRepository.getByUserId(command.hostUserId());
-
+        User host = getUser(command.hostUserId());
         if (gameParticipantRepository.existsActiveGameByUserId(host.getId())) {
             throw new ApplicationException(GameParticipantException.ALREADY_PARTICIPATING);
         }
@@ -75,6 +75,14 @@ public class GameService {
         saveHostAsParticipant(game, host);
 
         return GameCreateResult.from(game);
+    }
+
+    private User getUser(Long userId) {
+        User user = userRepository.getByUserId(userId);
+        if (!user.hasAgreedRequiredTerms()) {
+            throw  new ApplicationException(UserException.REQUIRED_TERMS_NOT_AGREED);
+        }
+        return user;
     }
 
     private Game saveGame(GameCreateCommand command, String inviteCode) {

--- a/src/main/java/com/team/cops_and_robbers/game/game/presentation/GameControllerDocs.java
+++ b/src/main/java/com/team/cops_and_robbers/game/game/presentation/GameControllerDocs.java
@@ -14,6 +14,7 @@ import com.team.cops_and_robbers.game.game.presentation.dto.response.GameCreateR
 import com.team.cops_and_robbers.game.game.presentation.dto.response.GameInfoResponse;
 import com.team.cops_and_robbers.game.game.presentation.dto.response.GameSettingsUpdateResponse;
 import com.team.cops_and_robbers.game.participant.exception.GameParticipantException;
+import com.team.cops_and_robbers.user.exception.UserException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -36,6 +37,7 @@ public interface GameControllerDocs {
             security = @SecurityRequirement(name = "JWT")
     )
     @ApiErrorCode(value = GameAreaException.class, codes = {"INVALID_JAIL_RADIUS", "JAIL_OUTSIDE_PLAYGROUND"})
+    @ApiErrorCode(value = UserException.class, codes = {"REQUIRED_TERMS_NOT_AGREED"})
     @ApiErrorCode(value = GameException.class, codes = {"INVALID_LOCATION_INTERVAL", "INVALID_POLICE_WAIT_TIME"})
     @ApiErrorCode(value = GameParticipantException.class, codes = {"ALREADY_PARTICIPATING"})
     @ApiErrorCode(value = CommonException.class, codes = {"INVALID_INPUT_VALUE"})

--- a/src/main/java/com/team/cops_and_robbers/game/participant/application/GameParticipantService.java
+++ b/src/main/java/com/team/cops_and_robbers/game/participant/application/GameParticipantService.java
@@ -17,6 +17,7 @@ import com.team.cops_and_robbers.game.participant.repository.GameParticipantRepo
 import com.team.cops_and_robbers.play.lobby.application.LobbyEventFactory;
 import com.team.cops_and_robbers.play.lobby.domain.LobbyEvent;
 import com.team.cops_and_robbers.user.domain.User;
+import com.team.cops_and_robbers.user.exception.UserException;
 import com.team.cops_and_robbers.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
@@ -45,7 +46,8 @@ public class GameParticipantService {
         Game game = gameRepository.getByInviteCode(command.inviteCode());
         validateJoinable(command.userId(), game);
 
-        User user = userRepository.getByUserId(command.userId());
+        User user = getUser(command.userId());
+
         GameParticipant participant = GameParticipant.createParticipant(game, user, false);
         gameParticipantRepository.save(participant);
 
@@ -71,6 +73,14 @@ public class GameParticipantService {
         if (participantCount >= game.getMaxParticipants()) {
             throw new ApplicationException(GameParticipantException.GAME_FULL);
         }
+    }
+
+    private User getUser(Long userId) {
+        User user = userRepository.getByUserId(userId);
+        if (!user.hasAgreedRequiredTerms()) {
+            throw  new ApplicationException(UserException.REQUIRED_TERMS_NOT_AGREED);
+        }
+        return user;
     }
 
     @Transactional

--- a/src/main/java/com/team/cops_and_robbers/game/participant/presentation/GameParticipantControllerDocs.java
+++ b/src/main/java/com/team/cops_and_robbers/game/participant/presentation/GameParticipantControllerDocs.java
@@ -10,6 +10,7 @@ import com.team.cops_and_robbers.game.participant.presentation.dto.request.GameJ
 import com.team.cops_and_robbers.game.participant.presentation.dto.response.GameJoinResponse;
 import com.team.cops_and_robbers.game.participant.presentation.dto.response.GameLeaveResponse;
 import com.team.cops_and_robbers.game.participant.presentation.dto.response.GameParticipantListResponse;
+import com.team.cops_and_robbers.user.exception.UserException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -29,6 +30,7 @@ public interface GameParticipantControllerDocs {
             security = @SecurityRequirement(name = "JWT")
     )
     @ApiErrorCode(value = GameParticipantException.class, codes = {"ALREADY_PARTICIPATING", "GAME_ALREADY_STARTED", "GAME_FULL", "INVALID_INVITE_CODE"})
+    @ApiErrorCode(value = UserException.class, codes = {"REQUIRED_TERMS_NOT_AGREED"})
     @ApiErrorCode(value = CommonException.class, codes = {"INVALID_INPUT_VALUE"})
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "게임 참여 성공")

--- a/src/main/java/com/team/cops_and_robbers/user/application/UserService.java
+++ b/src/main/java/com/team/cops_and_robbers/user/application/UserService.java
@@ -12,6 +12,7 @@ import com.team.cops_and_robbers.game.game.domain.Game;
 import com.team.cops_and_robbers.game.game.repository.GameRepository;
 import com.team.cops_and_robbers.game.participant.domain.GameParticipant;
 import com.team.cops_and_robbers.game.participant.repository.GameParticipantRepository;
+import com.team.cops_and_robbers.user.application.dto.command.AgreementCommand;
 import com.team.cops_and_robbers.user.application.dto.command.NicknameUpdateCommand;
 import com.team.cops_and_robbers.user.application.dto.result.UserGameInfoResult;
 import com.team.cops_and_robbers.user.domain.User;
@@ -115,5 +116,15 @@ public class UserService {
             }
             throw new InfrastructureException(AuthException.FIREBASE_SERVER_ERROR);
         }
+    }
+
+    @Transactional
+    public void updateTermsAgreement(AgreementCommand command) {
+        User user = userRepository.getByUserId(command.userId());
+
+        if (!command.hasRequiredTermsAgreed()) {
+            throw new ApplicationException(UserException.REQUIRED_TERMS_NOT_AGREED);
+        }
+        user.agree(command.marketing(), LocalDateTime.now(clock));
     }
 }

--- a/src/main/java/com/team/cops_and_robbers/user/application/UserService.java
+++ b/src/main/java/com/team/cops_and_robbers/user/application/UserService.java
@@ -125,6 +125,6 @@ public class UserService {
         if (!command.hasRequiredTermsAgreed()) {
             throw new ApplicationException(UserException.REQUIRED_TERMS_NOT_AGREED);
         }
-        user.agree(command.marketing(), LocalDateTime.now(clock));
+        user.agreeTerms(command.marketing(), LocalDateTime.now(clock));
     }
 }

--- a/src/main/java/com/team/cops_and_robbers/user/application/dto/command/AgreementCommand.java
+++ b/src/main/java/com/team/cops_and_robbers/user/application/dto/command/AgreementCommand.java
@@ -2,19 +2,19 @@ package com.team.cops_and_robbers.user.application.dto.command;
 
 public record AgreementCommand(
         Long userId,
-        boolean termsOfService,
-        boolean privacyPolicy,
-        boolean locationTerms,
-        boolean marketing
+        Boolean termsOfService,
+        Boolean privacyPolicy,
+        Boolean locationTerms,
+        Boolean marketing
 ) {
     public boolean hasRequiredTermsAgreed() {
         return termsOfService && privacyPolicy && locationTerms;
     }
 
     public static AgreementCommand of(
-            Long userId, boolean termsOfService,
-            boolean privacyPolicy, boolean locationTerms,
-            boolean marketing
+            Long userId, Boolean termsOfService,
+            Boolean privacyPolicy, Boolean locationTerms,
+            Boolean marketing
     ) {
         return new AgreementCommand(
                 userId,

--- a/src/main/java/com/team/cops_and_robbers/user/application/dto/command/AgreementCommand.java
+++ b/src/main/java/com/team/cops_and_robbers/user/application/dto/command/AgreementCommand.java
@@ -1,0 +1,27 @@
+package com.team.cops_and_robbers.user.application.dto.command;
+
+public record AgreementCommand(
+        Long userId,
+        boolean termsOfService,
+        boolean privacyPolicy,
+        boolean locationTerms,
+        boolean marketing
+) {
+    public boolean hasRequiredTermsAgreed() {
+        return termsOfService && privacyPolicy && locationTerms;
+    }
+
+    public static AgreementCommand of(
+            Long userId, boolean termsOfService,
+            boolean privacyPolicy, boolean locationTerms,
+            boolean marketing
+    ) {
+        return new AgreementCommand(
+                userId,
+                termsOfService,
+                privacyPolicy,
+                locationTerms,
+                marketing
+        );
+    }
+}

--- a/src/main/java/com/team/cops_and_robbers/user/domain/User.java
+++ b/src/main/java/com/team/cops_and_robbers/user/domain/User.java
@@ -84,12 +84,26 @@ public class User extends BaseTimeEntity {
         return this.locationTermsAgreed && this.termsOfServiceAgreed && this.privacyPolicyAgreed;
     }
 
-    public void agree(boolean marketing, LocalDateTime now) {
+    public void agreeTerms(boolean marketing, LocalDateTime now) {
+        agreeRequiredTerms(now);
+        updateMarketingPush(marketing, now);
+    }
+
+    private void updateMarketingPush(boolean marketing, LocalDateTime now) {
+        this.allowMarketingPush = marketing;
+        if (!marketing) {
+            this.marketingAgreedAt = null;
+        } else if (this.marketingAgreedAt == null) {
+            this.marketingAgreedAt = now;
+        }
+    }
+
+    private void agreeRequiredTerms(LocalDateTime now) {
         this.termsOfServiceAgreed = true;
         this.privacyPolicyAgreed = true;
         this.locationTermsAgreed = true;
-        this.termsAgreedAt = now;
-        this.allowMarketingPush = marketing;
-        this.marketingAgreedAt = marketing ? now : null;
+        if (this.termsAgreedAt == null) {
+            this.termsAgreedAt = now;
+        }
     }
 }

--- a/src/main/java/com/team/cops_and_robbers/user/domain/User.java
+++ b/src/main/java/com/team/cops_and_robbers/user/domain/User.java
@@ -80,7 +80,11 @@ public class User extends BaseTimeEntity {
         return this.nickname.equals(modifiedNickname);
     }
 
-    public void agreeToEssentialTerms() {
+    public boolean hasAgreedRequiredTerms() {
+        return this.locationTermsAgreed && this.termsOfServiceAgreed && this.privacyPolicyAgreed;
+    }
+
+    public void agreeToRequiredTerms() {
         this.termsOfServiceAgreed = true;
         this.privacyPolicyAgreed = true;
         this.locationTermsAgreed = true;

--- a/src/main/java/com/team/cops_and_robbers/user/domain/User.java
+++ b/src/main/java/com/team/cops_and_robbers/user/domain/User.java
@@ -90,8 +90,6 @@ public class User extends BaseTimeEntity {
         this.locationTermsAgreed = true;
         this.termsAgreedAt = now;
         this.allowMarketingPush = marketing;
-        if (marketing) {
-            this.marketingAgreedAt = now;
-        }
+        this.marketingAgreedAt = marketing ? now : null;
     }
 }

--- a/src/main/java/com/team/cops_and_robbers/user/domain/User.java
+++ b/src/main/java/com/team/cops_and_robbers/user/domain/User.java
@@ -84,13 +84,14 @@ public class User extends BaseTimeEntity {
         return this.locationTermsAgreed && this.termsOfServiceAgreed && this.privacyPolicyAgreed;
     }
 
-    public void agreeToRequiredTerms() {
+    public void agree(boolean marketing, LocalDateTime now) {
         this.termsOfServiceAgreed = true;
         this.privacyPolicyAgreed = true;
         this.locationTermsAgreed = true;
-    }
-
-    public void updateMarketingConsent(boolean isAgreed) {
-        this.allowMarketingPush = isAgreed;
+        this.termsAgreedAt = now;
+        this.allowMarketingPush = marketing;
+        if (marketing) {
+            this.marketingAgreedAt = now;
+        }
     }
 }

--- a/src/main/java/com/team/cops_and_robbers/user/domain/User.java
+++ b/src/main/java/com/team/cops_and_robbers/user/domain/User.java
@@ -8,6 +8,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Table(
         name = "users",
@@ -44,6 +46,19 @@ public class User extends BaseTimeEntity {
     @Column(nullable = false)
     private boolean allowMarketingPush;
 
+    @Column(nullable = false)
+    private boolean termsOfServiceAgreed;
+
+    @Column(nullable = false)
+    private boolean privacyPolicyAgreed;
+
+    @Column(nullable = false)
+    private boolean locationTermsAgreed;
+
+    private LocalDateTime termsAgreedAt;
+
+    private LocalDateTime marketingAgreedAt;
+
     public static User signUp(String socialId, SocialType socialType, String nickname) {
         return User.builder()
                 .socialId(socialId)
@@ -51,6 +66,9 @@ public class User extends BaseTimeEntity {
                 .nickname(nickname)
                 .allowGamePush(true)
                 .allowMarketingPush(false)
+                .termsOfServiceAgreed(false)
+                .privacyPolicyAgreed(false)
+                .locationTermsAgreed(false)
                 .build();
     }
 
@@ -60,5 +78,15 @@ public class User extends BaseTimeEntity {
 
     public boolean hasSameNickname(String modifiedNickname) {
         return this.nickname.equals(modifiedNickname);
+    }
+
+    public void agreeToEssentialTerms() {
+        this.termsOfServiceAgreed = true;
+        this.privacyPolicyAgreed = true;
+        this.locationTermsAgreed = true;
+    }
+
+    public void updateMarketingConsent(boolean isAgreed) {
+        this.allowMarketingPush = isAgreed;
     }
 }

--- a/src/main/java/com/team/cops_and_robbers/user/exception/UserException.java
+++ b/src/main/java/com/team/cops_and_robbers/user/exception/UserException.java
@@ -11,7 +11,8 @@ public enum UserException implements ExceptionCode {
 
     USER_NOT_FOUND(HttpStatus.UNAUTHORIZED, "존재하지 않는 회원", "해당 유저을 찾을 수 없습니다."),
     DUPLICATED_NICKNAME(HttpStatus.CONFLICT, "닉네임 중복", "이미 사용 중인 닉네임입니다. 다른 닉네임을 선택해주세요."),
-    CANNOT_WITHDRAW(HttpStatus.CONFLICT, "회원 탈퇴 불가", "진행 중인 게임 세션이 있어 탈퇴할 수 없습니다.")
+    CANNOT_WITHDRAW(HttpStatus.CONFLICT, "회원 탈퇴 불가", "진행 중인 게임 세션이 있어 탈퇴할 수 없습니다."),
+    REQUIRED_TERMS_NOT_AGREED(HttpStatus.BAD_REQUEST, "필수 약관 미동의", "필수 약관은 모두 동의해야 합니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/team/cops_and_robbers/user/presentation/UserController.java
+++ b/src/main/java/com/team/cops_and_robbers/user/presentation/UserController.java
@@ -9,6 +9,7 @@ import com.team.cops_and_robbers.user.application.dto.result.UserGameInfoResult;
 import com.team.cops_and_robbers.user.domain.User;
 import com.team.cops_and_robbers.user.presentation.dto.request.AgreementRequest;
 import com.team.cops_and_robbers.user.presentation.dto.request.NicknameUpdateRequest;
+import com.team.cops_and_robbers.user.presentation.dto.response.AgreementResponse;
 import com.team.cops_and_robbers.user.presentation.dto.response.DeleteAccountResponse;
 import com.team.cops_and_robbers.user.presentation.dto.response.MyPageResponse;
 import com.team.cops_and_robbers.user.presentation.dto.response.NicknameCheckResponse;
@@ -79,7 +80,16 @@ public class UserController implements UserControllerDocs {
     }
 
     /**
-     * 6. 사용자 이용 약관 동의 여부를 업데이트 합니다.
+     * 6. 사용자 이용 약관 동의 여부를 조회합니다.
+     */
+    @GetMapping("/agreements")
+    public ResponseEntity<AgreementResponse> getAgreements(@AuthUser LoginUser loginUser) {
+        User user = userService.getUserInfo(loginUser.userId());
+        return ResponseEntity.ok(AgreementResponse.from(user));
+    }
+
+    /**
+     * 7. 사용자 이용 약관 동의 여부를 업데이트 합니다.
      */
     @PostMapping("/agreements")
     public ResponseEntity<Void> updateTerms(

--- a/src/main/java/com/team/cops_and_robbers/user/presentation/UserController.java
+++ b/src/main/java/com/team/cops_and_robbers/user/presentation/UserController.java
@@ -91,7 +91,7 @@ public class UserController implements UserControllerDocs {
     /**
      * 7. 사용자 이용 약관 동의 여부를 업데이트 합니다.
      */
-    @PostMapping("/agreements")
+    @PutMapping("/agreements")
     public ResponseEntity<Void> updateTerms(
             @AuthUser LoginUser loginUser,
             @RequestBody @Valid AgreementRequest request

--- a/src/main/java/com/team/cops_and_robbers/user/presentation/UserController.java
+++ b/src/main/java/com/team/cops_and_robbers/user/presentation/UserController.java
@@ -3,9 +3,11 @@ package com.team.cops_and_robbers.user.presentation;
 import com.team.cops_and_robbers.auth.presentation.annotation.AuthUser;
 import com.team.cops_and_robbers.auth.presentation.resolver.LoginUser;
 import com.team.cops_and_robbers.user.application.UserService;
+import com.team.cops_and_robbers.user.application.dto.command.AgreementCommand;
 import com.team.cops_and_robbers.user.application.dto.command.NicknameUpdateCommand;
 import com.team.cops_and_robbers.user.application.dto.result.UserGameInfoResult;
 import com.team.cops_and_robbers.user.domain.User;
+import com.team.cops_and_robbers.user.presentation.dto.request.AgreementRequest;
 import com.team.cops_and_robbers.user.presentation.dto.request.NicknameUpdateRequest;
 import com.team.cops_and_robbers.user.presentation.dto.response.DeleteAccountResponse;
 import com.team.cops_and_robbers.user.presentation.dto.response.MyPageResponse;
@@ -74,5 +76,24 @@ public class UserController implements UserControllerDocs {
     public ResponseEntity<DeleteAccountResponse> deleteAccount(@AuthUser LoginUser loginUser) {
         userService.deleteAccount(loginUser.userId());
         return ResponseEntity.ok(DeleteAccountResponse.from());
+    }
+
+    /**
+     * 6. 사용자 이용 약관 동의 여부를 업데이트 합니다.
+     */
+    @PostMapping("/agreements")
+    public ResponseEntity<Void> updateTerms(
+            @AuthUser LoginUser loginUser,
+            @RequestBody @Valid AgreementRequest request
+    ) {
+        AgreementCommand command = AgreementCommand.of(
+                loginUser.userId(),
+                request.termsOfService(),
+                request.privacyPolicy(),
+                request.locationTerms(),
+                request.marketing()
+        );
+        userService.updateTermsAgreement(command);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/team/cops_and_robbers/user/presentation/UserControllerDocs.java
+++ b/src/main/java/com/team/cops_and_robbers/user/presentation/UserControllerDocs.java
@@ -4,6 +4,7 @@ import com.team.cops_and_robbers.auth.presentation.resolver.LoginUser;
 import com.team.cops_and_robbers.common.exception.CommonException;
 import com.team.cops_and_robbers.common.swagger.ApiErrorCode;
 import com.team.cops_and_robbers.user.exception.UserException;
+import com.team.cops_and_robbers.user.presentation.dto.request.AgreementRequest;
 import com.team.cops_and_robbers.user.presentation.dto.request.NicknameUpdateRequest;
 import com.team.cops_and_robbers.user.presentation.dto.response.DeleteAccountResponse;
 import com.team.cops_and_robbers.user.presentation.dto.response.MyPageResponse;
@@ -73,4 +74,17 @@ public interface UserControllerDocs {
             @ApiResponse(responseCode = "200", description = "탈퇴 성공")
     })
     ResponseEntity<DeleteAccountResponse> deleteAccount(@Parameter(hidden = true) LoginUser loginUser);
+
+    @Operation(summary = "약관 동의",
+            description = "이용약관, 개인정보처리방침, 위치정보 이용약관(필수), 마케팅 수신 동의(선택)를 저장합니다. 필수 동의 약관들은 모두 true 여야 합니다."
+    )
+    @ApiErrorCode(value = UserException.class, codes = {"USER_NOT_FOUND", "REQUIRED_TERMS_NOT_AGREED"})
+    @ApiErrorCode(value = CommonException.class, codes = {"INVALID_INPUT_VALUE"})
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "약관 동의 저장 성공 (응답 본문 없음)")
+    })
+    ResponseEntity<Void> updateTerms(
+            @Parameter(hidden = true) LoginUser loginUser,
+            @RequestBody @Valid AgreementRequest request
+    );
 }

--- a/src/main/java/com/team/cops_and_robbers/user/presentation/UserControllerDocs.java
+++ b/src/main/java/com/team/cops_and_robbers/user/presentation/UserControllerDocs.java
@@ -6,10 +6,7 @@ import com.team.cops_and_robbers.common.swagger.ApiErrorCode;
 import com.team.cops_and_robbers.user.exception.UserException;
 import com.team.cops_and_robbers.user.presentation.dto.request.AgreementRequest;
 import com.team.cops_and_robbers.user.presentation.dto.request.NicknameUpdateRequest;
-import com.team.cops_and_robbers.user.presentation.dto.response.DeleteAccountResponse;
-import com.team.cops_and_robbers.user.presentation.dto.response.MyPageResponse;
-import com.team.cops_and_robbers.user.presentation.dto.response.NicknameCheckResponse;
-import com.team.cops_and_robbers.user.presentation.dto.response.UserGameInfoResponse;
+import com.team.cops_and_robbers.user.presentation.dto.response.*;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -74,6 +71,17 @@ public interface UserControllerDocs {
             @ApiResponse(responseCode = "200", description = "탈퇴 성공")
     })
     ResponseEntity<DeleteAccountResponse> deleteAccount(@Parameter(hidden = true) LoginUser loginUser);
+
+
+    @Operation(summary = "약관 동의 현황 조회",
+            description = "로그인한 사용자의 약관 동의 현황을 조회합니다."
+    )
+    @ApiErrorCode(value = UserException.class, codes = {"USER_NOT_FOUND"})
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공")
+    })
+    ResponseEntity<AgreementResponse> getAgreements(@Parameter(hidden = true) LoginUser loginUser);
+
 
     @Operation(summary = "약관 동의",
             description = "이용약관, 개인정보처리방침, 위치정보 이용약관(필수), 마케팅 수신 동의(선택)를 저장합니다. 필수 동의 약관들은 모두 true 여야 합니다."

--- a/src/main/java/com/team/cops_and_robbers/user/presentation/dto/request/AgreementRequest.java
+++ b/src/main/java/com/team/cops_and_robbers/user/presentation/dto/request/AgreementRequest.java
@@ -1,0 +1,20 @@
+package com.team.cops_and_robbers.user.presentation.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+public record AgreementRequest(
+        @Schema(description = "이용약관 동의 여부", example = "true")
+        @NotNull(message = "이용약관 동의 여부는 필수 입력 항목입니다.")
+        boolean termsOfService,
+        @Schema(description = "개인정보처리방침 동의 여부", example = "true")
+        @NotNull(message = "개인정보처리방침 동의 여부는 필수 입력 항목입니다.")
+        boolean privacyPolicy,
+        @Schema(description = "위치정보 이용약관 동의 여부", example = "true")
+        @NotNull(message = "위치정보 이용약관 동의 여부는 필수 입력 항목입니다.")
+        boolean locationTerms,
+        @Schema(description = "마케팅 수신 동의 여부", example = "true")
+        @NotNull(message = "마케팅 수신 동의 여부는 필수 입력 항목입니다.")
+        boolean marketing
+) {
+}

--- a/src/main/java/com/team/cops_and_robbers/user/presentation/dto/request/AgreementRequest.java
+++ b/src/main/java/com/team/cops_and_robbers/user/presentation/dto/request/AgreementRequest.java
@@ -6,15 +6,15 @@ import jakarta.validation.constraints.NotNull;
 public record AgreementRequest(
         @Schema(description = "이용약관 동의 여부", example = "true")
         @NotNull(message = "이용약관 동의 여부는 필수 입력 항목입니다.")
-        boolean termsOfService,
+        Boolean termsOfService,
         @Schema(description = "개인정보처리방침 동의 여부", example = "true")
         @NotNull(message = "개인정보처리방침 동의 여부는 필수 입력 항목입니다.")
-        boolean privacyPolicy,
+        Boolean privacyPolicy,
         @Schema(description = "위치정보 이용약관 동의 여부", example = "true")
         @NotNull(message = "위치정보 이용약관 동의 여부는 필수 입력 항목입니다.")
-        boolean locationTerms,
+        Boolean locationTerms,
         @Schema(description = "마케팅 수신 동의 여부", example = "true")
         @NotNull(message = "마케팅 수신 동의 여부는 필수 입력 항목입니다.")
-        boolean marketing
+        Boolean marketing
 ) {
 }

--- a/src/main/java/com/team/cops_and_robbers/user/presentation/dto/response/AgreementResponse.java
+++ b/src/main/java/com/team/cops_and_robbers/user/presentation/dto/response/AgreementResponse.java
@@ -1,0 +1,40 @@
+package com.team.cops_and_robbers.user.presentation.dto.response;
+
+import com.team.cops_and_robbers.common.util.TimestampUtil;
+import com.team.cops_and_robbers.user.domain.User;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+public record AgreementResponse(
+        @Schema(description = "이용약관 동의 여부", example = "true")
+        boolean termsOfServiceAgreed,
+        @Schema(description = "개인정보처리방침 동의 여부", example = "true")
+        boolean privacyPolicyAgreed,
+        @Schema(description = "위치정보 이용약관 동의 여부", example = "true")
+        boolean locationTermsAgreed,
+        @Schema(description = "필수 약관 동의 시각 (미동의 시 null)", example = "2026-04-15T10:00:00+09:00")
+        String termsAgreedAt,
+        @Schema(description = "마케팅 수신 동의 여부", example = "false")
+        boolean marketingAgreed,
+        @Schema(description = "마케팅 동의 시각 (미동의 시 null)", example = "null")
+        String marketingAgreedAt
+) {
+    public static AgreementResponse from(User user) {
+        return new AgreementResponse(
+                user.isTermsOfServiceAgreed(),
+                user.isPrivacyPolicyAgreed(),
+                user.isLocationTermsAgreed(),
+                toIsoStringOrNull(user.getTermsAgreedAt()),
+                user.isAllowMarketingPush(),
+                toIsoStringOrNull(user.getMarketingAgreedAt())
+        );
+    }
+
+    private static String toIsoStringOrNull(LocalDateTime localDateTime) {
+        if (localDateTime == null) {
+            return null;
+        }
+        return TimestampUtil.toIsoString(localDateTime);
+    }
+}

--- a/src/main/resources/db/migration/V260415_1200__alter_users_add_agreement.sql
+++ b/src/main/resources/db/migration/V260415_1200__alter_users_add_agreement.sql
@@ -1,0 +1,6 @@
+ALTER TABLE users
+    ADD COLUMN terms_of_service_agreed BOOLEAN   NOT NULL DEFAULT FALSE,
+    ADD COLUMN privacy_policy_agreed   BOOLEAN   NOT NULL DEFAULT FALSE,
+    ADD COLUMN location_terms_agreed   BOOLEAN   NOT NULL DEFAULT FALSE,
+    ADD COLUMN terms_agreed_at         TIMESTAMP,
+    ADD COLUMN marketing_agreed_at     TIMESTAMP;

--- a/src/test/java/com/team/cops_and_robbers/common/fixture/UserFixture.java
+++ b/src/test/java/com/team/cops_and_robbers/common/fixture/UserFixture.java
@@ -14,6 +14,9 @@ public class UserFixture {
                 .nickname("testUser")
                 .allowGamePush(true)
                 .allowMarketingPush(false)
+                .termsOfServiceAgreed(true)
+                .privacyPolicyAgreed(true)
+                .locationTermsAgreed(true)
                 .build();
     }
 
@@ -24,6 +27,9 @@ public class UserFixture {
                 .nickname(nickname)
                 .allowGamePush(true)
                 .allowMarketingPush(false)
+                .termsOfServiceAgreed(true)
+                .privacyPolicyAgreed(true)
+                .locationTermsAgreed(true)
                 .build();
     }
 
@@ -34,6 +40,9 @@ public class UserFixture {
                 .nickname("kakaoUser")
                 .allowGamePush(true)
                 .allowMarketingPush(false)
+                .termsOfServiceAgreed(true)
+                .privacyPolicyAgreed(true)
+                .locationTermsAgreed(true)
                 .build();
     }
 
@@ -44,6 +53,9 @@ public class UserFixture {
                 .nickname("googleUser")
                 .allowGamePush(true)
                 .allowMarketingPush(false)
+                .termsOfServiceAgreed(true)
+                .privacyPolicyAgreed(true)
+                .locationTermsAgreed(true)
                 .build();
     }
 
@@ -54,6 +66,9 @@ public class UserFixture {
                 .nickname("appleUser")
                 .allowGamePush(true)
                 .allowMarketingPush(false)
+                .termsOfServiceAgreed(true)
+                .privacyPolicyAgreed(true)
+                .locationTermsAgreed(true)
                 .build();
     }
 }

--- a/src/test/java/com/team/cops_and_robbers/common/fixture/UserFixture.java
+++ b/src/test/java/com/team/cops_and_robbers/common/fixture/UserFixture.java
@@ -71,4 +71,17 @@ public class UserFixture {
                 .locationTermsAgreed(true)
                 .build();
     }
+
+    public static User USER_WITHOUT_TERMS(String nickname) {
+        return User.builder()
+                .socialId(UUID.randomUUID().toString())
+                .socialType(SocialType.GOOGLE)
+                .nickname(nickname)
+                .allowGamePush(true)
+                .allowMarketingPush(false)
+                .termsOfServiceAgreed(false)
+                .privacyPolicyAgreed(false)
+                .locationTermsAgreed(false)
+                .build();
+    }
 }

--- a/src/test/java/com/team/cops_and_robbers/game/game/application/GameServiceTest.java
+++ b/src/test/java/com/team/cops_and_robbers/game/game/application/GameServiceTest.java
@@ -32,6 +32,8 @@ import static com.team.cops_and_robbers.common.fixture.GameFixture.WAITING_GAME;
 import static com.team.cops_and_robbers.common.fixture.GameParticipantFixture.GUEST_PARTICIPANT;
 import static com.team.cops_and_robbers.common.fixture.GameParticipantFixture.HOST_PARTICIPANT;
 import static com.team.cops_and_robbers.common.fixture.UserFixture.USER;
+import static com.team.cops_and_robbers.common.fixture.UserFixture.USER_WITHOUT_TERMS;
+import com.team.cops_and_robbers.user.exception.UserException;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -118,6 +120,24 @@ class GameServiceTest extends ServiceUnitTest {
 
             then(gameRepository).should(never()).save(any(Game.class));
             then(gameAreaRepository).should(never()).save(any(GameArea.class));
+            then(gameParticipantRepository).should(never()).save(any(GameParticipant.class));
+        }
+
+        @Test
+        void 필수_약관에_미동의한_유저라면_예외가_발생한다() {
+            // given
+            User unagreedHost = USER_WITHOUT_TERMS("unagreedHost");
+            setId(unagreedHost, TEST_HOST_ID);
+            GameCreateCommand command = createGameCommand(unagreedHost.getId());
+
+            given(userRepository.getByUserId(unagreedHost.getId())).willReturn(unagreedHost);
+
+            // when & then
+            assertThatThrownBy(() -> gameService.createGame(command))
+                    .isInstanceOf(ApplicationException.class)
+                    .hasMessage(UserException.REQUIRED_TERMS_NOT_AGREED.getDetail());
+
+            then(gameRepository).should(never()).save(any(Game.class));
             then(gameParticipantRepository).should(never()).save(any(GameParticipant.class));
         }
     }

--- a/src/test/java/com/team/cops_and_robbers/game/game/presentation/GameControllerTest.java
+++ b/src/test/java/com/team/cops_and_robbers/game/game/presentation/GameControllerTest.java
@@ -3,6 +3,7 @@ package com.team.cops_and_robbers.game.game.presentation;
 import com.team.cops_and_robbers.common.ControllerTest;
 import com.team.cops_and_robbers.common.fixture.GameAreaFixture;
 import com.team.cops_and_robbers.common.fixture.GameFixture;
+import com.team.cops_and_robbers.common.fixture.UserFixture;
 import com.team.cops_and_robbers.game.game.domain.Game;
 import com.team.cops_and_robbers.game.game.presentation.dto.request.CoordinatesRequest;
 import com.team.cops_and_robbers.game.game.presentation.dto.request.GameAreaRequest;
@@ -147,6 +148,24 @@ class GameControllerTest extends ControllerTest {
 
             // then
             assertThat(response.statusCode()).isEqualTo(401);
+        }
+
+        @Test
+        void 필수_약관에_미동의한_유저라면_400_BadRequest를_응답한다() {
+            // given
+            User unagreedUser = userRepository.save(UserFixture.USER_WITHOUT_TERMS("unagreedHost"));
+            String unagreedToken = givenAccessToken(unagreedUser);
+
+            // when
+            ExtractableResponse<Response> response = authenticated(unagreedToken)
+                    .body(createGameCreateRequest())
+                    .when()
+                    .post(GAME_API_URL)
+                    .then()
+                    .extract();
+
+            // then
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
         }
     }
 

--- a/src/test/java/com/team/cops_and_robbers/game/participant/application/GameParticipantServiceTest.java
+++ b/src/test/java/com/team/cops_and_robbers/game/participant/application/GameParticipantServiceTest.java
@@ -16,8 +16,7 @@ import com.team.cops_and_robbers.game.participant.exception.GameParticipantExcep
 import com.team.cops_and_robbers.play.lobby.application.LobbyEventFactory;
 import com.team.cops_and_robbers.play.lobby.domain.LobbyEvent;
 import com.team.cops_and_robbers.user.domain.User;
-
-import java.util.List;
+import com.team.cops_and_robbers.user.exception.UserException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -26,20 +25,20 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.springframework.context.ApplicationEventPublisher;
 
+import java.util.List;
+
 import static com.team.cops_and_robbers.common.fixture.GameFixture.IN_PROGRESS_GAME;
 import static com.team.cops_and_robbers.common.fixture.GameFixture.WAITING_GAME;
-import static com.team.cops_and_robbers.common.fixture.GameParticipantFixture.ALIVE_POLICE;
-import static com.team.cops_and_robbers.common.fixture.GameParticipantFixture.ALIVE_ROBBER;
-import static com.team.cops_and_robbers.common.fixture.GameParticipantFixture.GUEST_PARTICIPANT;
-import static com.team.cops_and_robbers.common.fixture.GameParticipantFixture.HOST_PARTICIPANT;
-import static com.team.cops_and_robbers.common.fixture.GameParticipantFixture.WAITING_POLICE;
+import static com.team.cops_and_robbers.common.fixture.GameParticipantFixture.*;
 import static com.team.cops_and_robbers.common.fixture.UserFixture.USER;
+import static com.team.cops_and_robbers.common.fixture.UserFixture.USER_WITHOUT_TERMS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 
 class GameParticipantServiceTest extends ServiceUnitTest {
@@ -136,6 +135,25 @@ class GameParticipantServiceTest extends ServiceUnitTest {
             assertThatThrownBy(() -> gameParticipantService.joinGame(command))
                     .isInstanceOf(ApplicationException.class)
                     .hasMessageContaining(GameParticipantException.GAME_ALREADY_STARTED.getDetail());
+        }
+
+        @Test
+        void 필수_약관에_미동의한_유저라면_예외가_발생한다() {
+            // given
+            User unagreedUser = USER_WITHOUT_TERMS("unagreedUser");
+            setId(unagreedUser, TEST_USER_ID);
+            GameJoinCommand command = createGameJoinCommand(unagreedUser.getId(), INVITE_CODE);
+
+            given(gameRepository.getByInviteCode(INVITE_CODE)).willReturn(waitingGame);
+            given(gameParticipantRepository.existsActiveGameByUserId(unagreedUser.getId())).willReturn(false);
+            given(userRepository.getByUserId(unagreedUser.getId())).willReturn(unagreedUser);
+
+            // when & then
+            assertThatThrownBy(() -> gameParticipantService.joinGame(command))
+                    .isInstanceOf(ApplicationException.class)
+                    .hasMessage(UserException.REQUIRED_TERMS_NOT_AGREED.getDetail());
+
+            then(gameParticipantRepository).should(never()).save(any(GameParticipant.class));
         }
 
         @Test

--- a/src/test/java/com/team/cops_and_robbers/game/participant/presentation/GameParticipantControllerTest.java
+++ b/src/test/java/com/team/cops_and_robbers/game/participant/presentation/GameParticipantControllerTest.java
@@ -2,6 +2,7 @@ package com.team.cops_and_robbers.game.participant.presentation;
 
 import com.team.cops_and_robbers.common.ControllerTest;
 import com.team.cops_and_robbers.common.fixture.GameFixture;
+import com.team.cops_and_robbers.common.fixture.UserFixture;
 import com.team.cops_and_robbers.game.game.domain.Game;
 import com.team.cops_and_robbers.game.game.domain.GameStatus;
 import com.team.cops_and_robbers.game.participant.domain.GameParticipant;
@@ -159,6 +160,25 @@ class GameParticipantControllerTest extends ControllerTest {
 
             // then
             assertThat(response.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+        }
+
+        @Test
+        void 필수_약관에_미동의한_유저라면_400_BadRequest를_응답한다() {
+            // given
+            User unagreedUser = userRepository.save(UserFixture.USER_WITHOUT_TERMS("unagreedGuest"));
+            String unagreedToken = givenAccessToken(unagreedUser);
+            GameJoinRequest request = new GameJoinRequest(waitingGame.getInviteCode());
+
+            // when
+            ExtractableResponse<Response> response = authenticated(unagreedToken)
+                    .body(request)
+                    .when()
+                    .post(JOIN_URL)
+                    .then()
+                    .extract();
+
+            // then
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
         }
 
         @Test

--- a/src/test/java/com/team/cops_and_robbers/user/application/UserServiceTest.java
+++ b/src/test/java/com/team/cops_and_robbers/user/application/UserServiceTest.java
@@ -12,6 +12,7 @@ import com.team.cops_and_robbers.game.game.domain.Game;
 import com.team.cops_and_robbers.game.game.domain.GameStatus;
 import com.team.cops_and_robbers.game.participant.domain.GameParticipant;
 import com.team.cops_and_robbers.game.participant.domain.Team;
+import com.team.cops_and_robbers.user.application.dto.command.AgreementCommand;
 import com.team.cops_and_robbers.user.application.dto.command.NicknameUpdateCommand;
 import com.team.cops_and_robbers.user.application.dto.result.UserGameInfoResult;
 import com.team.cops_and_robbers.user.domain.User;
@@ -61,6 +62,54 @@ class UserServiceTest extends ServiceUnitTest {
     void setUp() {
         user = USER();
         setId(user, TEST_USER_ID);
+    }
+
+    @Nested
+    @DisplayName("약관 동의")
+    class UpdateTermsAgreement {
+
+        @Test
+        void 필수_약관과_마케팅_미동의로_약관_동의에_성공한다() {
+            // given
+            AgreementCommand command = AgreementCommand.of(TEST_USER_ID, true, true, true, false);
+            given(userRepository.getByUserId(TEST_USER_ID)).willReturn(user);
+
+            // when
+            userService.updateTermsAgreement(command);
+
+            // then
+            assertThat(user.isTermsOfServiceAgreed()).isTrue();
+            assertThat(user.isPrivacyPolicyAgreed()).isTrue();
+            assertThat(user.isLocationTermsAgreed()).isTrue();
+            assertThat(user.getTermsAgreedAt()).isNotNull();
+            assertThat(user.isAllowMarketingPush()).isFalse();
+            assertThat(user.getMarketingAgreedAt()).isNull();
+        }
+
+        @Test
+        void 마케팅_동의시_마케팅_동의_시각이_함께_저장된다() {
+            // given
+            AgreementCommand command = AgreementCommand.of(TEST_USER_ID, true, true, true, true);
+            given(userRepository.getByUserId(TEST_USER_ID)).willReturn(user);
+
+            // when
+            userService.updateTermsAgreement(command);
+
+            // then
+            assertThat(user.isAllowMarketingPush()).isTrue();
+            assertThat(user.getMarketingAgreedAt()).isNotNull();
+        }
+
+        @Test
+        void 필수_약관에_미동의하면_예외가_발생한다() {
+            // given
+            AgreementCommand command = AgreementCommand.of(TEST_USER_ID, false, true, true, false);
+
+            // when & then
+            assertThatThrownBy(() -> userService.updateTermsAgreement(command))
+                    .isInstanceOf(ApplicationException.class)
+                    .hasMessage(UserException.REQUIRED_TERMS_NOT_AGREED.getDetail());
+        }
     }
 
     @Nested

--- a/src/test/java/com/team/cops_and_robbers/user/presentation/UserControllerTest.java
+++ b/src/test/java/com/team/cops_and_robbers/user/presentation/UserControllerTest.java
@@ -17,6 +17,7 @@ import com.team.cops_and_robbers.game.participant.domain.GameParticipant;
 import com.team.cops_and_robbers.game.participant.domain.Team;
 import com.team.cops_and_robbers.user.domain.User;
 import com.team.cops_and_robbers.user.exception.UserException;
+import com.team.cops_and_robbers.user.presentation.dto.request.AgreementRequest;
 import com.team.cops_and_robbers.user.presentation.dto.request.NicknameUpdateRequest;
 import com.team.cops_and_robbers.user.presentation.dto.response.MyPageResponse;
 import com.team.cops_and_robbers.user.presentation.dto.response.NicknameCheckResponse;
@@ -42,6 +43,86 @@ class UserControllerTest extends ControllerTest {
 
     @Autowired
     private JdbcTemplate jdbcTemplate;
+
+    @Nested
+    @DisplayName("약관 동의 API")
+    class UpdateAgreements {
+
+        @Test
+        void 필수_약관에_모두_동의하면_204_NO_CONTENT를_응답한다() {
+            // given
+            User user = givenUser();
+            String accessToken = givenAccessToken(user);
+            AgreementRequest request = new AgreementRequest(true, true, true, false);
+
+            // when
+            ExtractableResponse<Response> extract = authenticated(accessToken)
+                    .body(request)
+                    .when()
+                    .post("/api/user/agreements")
+                    .then()
+                    .extract();
+
+            // then
+            User updatedUser = userRepository.getByUserId(user.getId());
+            assertSoftly(softly -> {
+                softly.assertThat(extract.statusCode()).isEqualTo(204);
+                softly.assertThat(updatedUser.isTermsOfServiceAgreed()).isTrue();
+                softly.assertThat(updatedUser.isPrivacyPolicyAgreed()).isTrue();
+                softly.assertThat(updatedUser.isLocationTermsAgreed()).isTrue();
+                softly.assertThat(updatedUser.getTermsAgreedAt()).isNotNull();
+                softly.assertThat(updatedUser.isAllowMarketingPush()).isFalse();
+                softly.assertThat(updatedUser.getMarketingAgreedAt()).isNull();
+            });
+        }
+
+        @Test
+        void 마케팅_동의시_마케팅_동의_시각이_함께_저장되고_204_NO_CONTENT를_응답한다() {
+            // given
+            User user = givenUser();
+            String accessToken = givenAccessToken(user);
+            AgreementRequest request = new AgreementRequest(true, true, true, true);
+
+            // when
+            ExtractableResponse<Response> extract = authenticated(accessToken)
+                    .body(request)
+                    .when()
+                    .post("/api/user/agreements")
+                    .then()
+                    .extract();
+
+            // then
+            User updatedUser = userRepository.getByUserId(user.getId());
+            assertSoftly(softly -> {
+                softly.assertThat(extract.statusCode()).isEqualTo(204);
+                softly.assertThat(updatedUser.isAllowMarketingPush()).isTrue();
+                softly.assertThat(updatedUser.getMarketingAgreedAt()).isNotNull();
+            });
+        }
+
+        @Test
+        void 필수_약관에_미동의하면_400_BAD_REQUEST를_응답한다() {
+            // given
+            User user = givenUser();
+            String accessToken = givenAccessToken(user);
+            AgreementRequest request = new AgreementRequest(false, true, true, false);
+
+            // when
+            ExtractableResponse<Response> extract = authenticated(accessToken)
+                    .body(request)
+                    .when()
+                    .post("/api/user/agreements")
+                    .then()
+                    .extract();
+
+            // then
+            ErrorResponse response = extract.as(ErrorResponse.class);
+            assertSoftly(softly -> {
+                softly.assertThat(extract.statusCode()).isEqualTo(400);
+                softly.assertThat(response.title()).isEqualTo(UserException.REQUIRED_TERMS_NOT_AGREED.getTitle());
+            });
+        }
+    }
 
     @Nested
     @DisplayName("내 정보 조회 API")

--- a/src/test/java/com/team/cops_and_robbers/user/presentation/UserControllerTest.java
+++ b/src/test/java/com/team/cops_and_robbers/user/presentation/UserControllerTest.java
@@ -59,7 +59,7 @@ class UserControllerTest extends ControllerTest {
             ExtractableResponse<Response> extract = authenticated(accessToken)
                     .body(request)
                     .when()
-                    .post("/api/user/agreements")
+                    .put("/api/user/agreements")
                     .then()
                     .extract();
 
@@ -87,7 +87,7 @@ class UserControllerTest extends ControllerTest {
             ExtractableResponse<Response> extract = authenticated(accessToken)
                     .body(request)
                     .when()
-                    .post("/api/user/agreements")
+                    .put("/api/user/agreements")
                     .then()
                     .extract();
 
@@ -111,7 +111,7 @@ class UserControllerTest extends ControllerTest {
             ExtractableResponse<Response> extract = authenticated(accessToken)
                     .body(request)
                     .when()
-                    .post("/api/user/agreements")
+                    .put("/api/user/agreements")
                     .then()
                     .extract();
 


### PR DESCRIPTION
## 📎 Issue 번호
<!-- PR과 연관된 이슈의 번호를 작성해주세요.
PR 머지 시 close 되어야 하는 이슈의 경우 이슈 번호 앞에 `closed` 키워드를 붙여주세요.  
ex) `closed #2` -->

- closed #78 

## ✨ 작업 내용
<!-- 핵심적으로 변경된 사항들을 간략하게 서술해주세요. -> 예시: S3 업로드 기능 추가 -->

이용약관 과 관련한 API들을 구현하였습니다.
- `PUT /api/user/agreements`
- `GET /api/user/agreements`


신규 로그인시 이용약관은 모두 false로 설정하고
put 요청으로 추후 동의 할 수 있도록 플로우를 구성했습니다
- login API 에서 동의 여부를 판단할 수 있는 필드를 추가했습니다.



이용약관 검증로직을 추가했습니다.
- 게임 방 생성시 필수 이용약관 동의 여부 검증
- 게임 방 참여 시 필수 이용약관 동의 여부 검증



## 🎯 리뷰 포인트
<!-- 리뷰시 중점적으로 봐주었으면 좋을 부분을 적어주세요.  
없다면 적지 않아도 됩니다. -->  
- 약관 동의 여부를 user 테이블에서 관리 하도록 했습니다 (join 오버헤드를 피하기 위해)

## 📝 기타
<!-- 위 항목 외에 공유하고 싶은 내용이 있다면 작성해주세요. 없다면 적지 않아도 됩니다.
-> 예: 작업 중 고민했던 점, 임시로 처리한 부분, 후속 작업 예정 등 -->



## ✅ 테스트
- [x] 수동 테스트 완료
- [x] 테스트 코드 완료
