### PR TITLE
fix: FCM 푸시 알림 미전송 버그 수정

### DIFF
--- a/src/main/java/com/team/cops_and_robbers/play/notification/application/GameFcmNotifier.java
+++ b/src/main/java/com/team/cops_and_robbers/play/notification/application/GameFcmNotifier.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Service;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
 
 @Slf4j
 @Service
@@ -24,16 +25,20 @@ public class GameFcmNotifier {
     private final InGameParticipantCacheRepository inGameParticipantCacheRepository;
 
     @Async("fcmExecutor")
-    public void notifySystemEvent(SystemEvent event) {
+    public CompletableFuture<Void> notifySystemEvent(SystemEvent event) {
         try {
             List<String> tokens = getGameTokens(event.gameId());
-            if (tokens.isEmpty()) return;
+            if (tokens.isEmpty()) {
+                log.warn("[FCM] No tokens found | gameId={}, type={}", event.gameId(), event.type());
+                return CompletableFuture.completedFuture(null);
+            }
 
             FcmPayload payload = resolveSystemPayload(event.type(), event.gameId());
             fcmService.send(new FcmMessage(tokens, payload.title(), payload.body(), payload.data()));
         } catch (Exception e) {
             log.error("[FCM] Async send failed | gameId={}, type={}", event.gameId(), event.type(), e);
         }
+        return CompletableFuture.completedFuture(null);
     }
 
     private List<String> getGameTokens(Long gameId) {

--- a/src/main/java/com/team/cops_and_robbers/play/system/application/GameEventConsumer.java
+++ b/src/main/java/com/team/cops_and_robbers/play/system/application/GameEventConsumer.java
@@ -6,7 +6,9 @@ import com.team.cops_and_robbers.game.participant.domain.ParticipantStatus;
 import com.team.cops_and_robbers.game.participant.domain.Team;
 import com.team.cops_and_robbers.game.participant.repository.GameParticipantRepository;
 import com.team.cops_and_robbers.play.location.application.RobberLocationService;
+import com.team.cops_and_robbers.play.notification.application.GameFcmNotifier;
 import com.team.cops_and_robbers.play.system.domain.GameScheduleEvent;
+import com.team.cops_and_robbers.play.system.domain.SystemEvent;
 import com.team.cops_and_robbers.play.system.domain.SystemEventData;
 import com.team.cops_and_robbers.play.system.infrastructure.GameScheduleQueue;
 import jakarta.annotation.PostConstruct;
@@ -33,6 +35,7 @@ public class GameEventConsumer {
     private final GameTerminationService gameTerminationService;
     private final SystemPublisher systemPublisher;
     private final SystemEventFactory systemEventFactory;
+    private final GameFcmNotifier gameFcmNotifier;
     private final TransactionTemplate transactionTemplate;
 
     private volatile Thread consumerThread;
@@ -109,7 +112,9 @@ public class GameEventConsumer {
                 gameParticipantRepository.updateStatusByGameIdAndTeam(
                         gameId, Team.POLICE, ParticipantStatus.ALIVE)
         );
-        systemPublisher.publish(systemEventFactory.createPoliceMoveStartEvent(gameId));
+        SystemEvent event = systemEventFactory.createPoliceMoveStartEvent(gameId);
+        systemPublisher.publish(event);
+        gameFcmNotifier.notifySystemEvent(event);
     }
 
     /**
@@ -118,7 +123,9 @@ public class GameEventConsumer {
     private void executeRobberLocationReveal(Game game) {
         List<SystemEventData.RobberLocation> locations =
                 robberLocationService.getCurrentRobberLocations(game.getId());
-        systemPublisher.publish(systemEventFactory.createRobberLocationRevealEvent(game.getId(), locations));
+        SystemEvent event = systemEventFactory.createRobberLocationRevealEvent(game.getId(), locations);
+        systemPublisher.publish(event);
+        gameFcmNotifier.notifySystemEvent(event);
 
         gameScheduleQueue.enqueueNextReveal(game);
     }

--- a/src/main/java/com/team/cops_and_robbers/play/system/application/SystemEventHandler.java
+++ b/src/main/java/com/team/cops_and_robbers/play/system/application/SystemEventHandler.java
@@ -22,11 +22,14 @@ public class SystemEventHandler {
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleSystemEvent(SystemEvent event) {
-        if (event.type() == SystemEventType.GAME_OVER) {
-            robberLocationService.clearRobberLocations(event.gameId());
-            inGameParticipantCacheService.clearCache(event.gameId());
-        }
         systemPublisher.publish(event);
-        gameFcmNotifier.notifySystemEvent(event);
+        if (event.type() == SystemEventType.GAME_OVER) {
+            gameFcmNotifier.notifySystemEvent(event).whenComplete((r, ex) -> {
+                robberLocationService.clearRobberLocations(event.gameId());
+                inGameParticipantCacheService.clearCache(event.gameId());
+            });
+        } else {
+            gameFcmNotifier.notifySystemEvent(event);
+        }
     }
 }


### PR DESCRIPTION
## 📎 Issue 번호
<!-- PR과 연관된 이슈의 번호를 작성해주세요.
PR 머지 시 close 되어야 하는 이슈의 경우 이슈 번호 앞에 `closed` 키워드를 붙여주세요.  
ex) `closed #2` -->

## ✨ 작업 내용
<!-- 핵심적으로 변경된 사항들을 간략하게 서술해주세요. -> 예시: S3 업로드 기능 추가 -->
- GAME_OVER 캐시 삭제 순서 수정
   - 기존에 캐시를 먼저 지운 후 FCM을 전송해서 항상 토큰을 못 찾는 문제 수정. FCM 전송 완료 후 whenComplete에서 캐시 삭제하도록 순서 변경
- FCM 직접 호출 추가
   - POLICE_MOVE_START, ROBBER_LOCATION_REVEAL 이벤트가 GameEventConsumer에서 직접 실행되어 FCM이 호출되지 않던 문제 수정
- 경고 로그 추가
   - FCM 토큰이 없을 때 [FCM] No tokens found 경고 로그 추가

## ✅ 테스트
- [ ] 수동 테스트 완료
- [ ] 테스트 코드 완료
