### PR TITLE
refactor: 에러 응답에 errorCode 필드 추가

### DIFF
--- a/src/main/java/com/team/cops_and_robbers/common/exception/ErrorResponse.java
+++ b/src/main/java/com/team/cops_and_robbers/common/exception/ErrorResponse.java
@@ -4,6 +4,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "에러 응답")
 public record ErrorResponse(
+        @Schema(description = "에러 코드", example = "INVALID_INPUT_VALUE")
+        String errorCode,
         @Schema(description = "에러 제목", example = "유효하지 않은 입력값")
         String title,
         @Schema(description = "HTTP 상태 코드", example = "400")
@@ -14,11 +16,11 @@ public record ErrorResponse(
         String instance
 ) {
     public static ErrorResponse of(ExceptionCode code, String instance) {
-        return new ErrorResponse(code.getTitle(), code.getHttpStatus().value(), code.getDetail(), instance);
+        return new ErrorResponse(code.getErrorCode(), code.getTitle(), code.getHttpStatus().value(), code.getDetail(), instance);
     }
 
     // 동적인 상세 메시지를 직접 응답에 지정
     public static ErrorResponse of(ExceptionCode code, String detail, String instance) {
-        return new ErrorResponse(code.getTitle(), code.getHttpStatus().value(), detail, instance);
+        return new ErrorResponse(code.getErrorCode(), code.getTitle(), code.getHttpStatus().value(), detail, instance);
     }
 }

--- a/src/main/java/com/team/cops_and_robbers/common/exception/ExceptionCode.java
+++ b/src/main/java/com/team/cops_and_robbers/common/exception/ExceptionCode.java
@@ -6,4 +6,7 @@ public interface ExceptionCode {
     HttpStatus getHttpStatus();
     String getTitle();
     String getDetail();
+    default String getErrorCode() {
+        return ((Enum<?>) this).name();
+    }
 }

--- a/src/main/java/com/team/cops_and_robbers/common/exception/StompExceptionHandler.java
+++ b/src/main/java/com/team/cops_and_robbers/common/exception/StompExceptionHandler.java
@@ -57,7 +57,8 @@ public class StompExceptionHandler extends StompSubProtocolErrorHandler {
         } catch (JsonProcessingException e) {
             log.error("[WebSocket Error] JSON Serialization Failed", e);
             jsonBody = String.format(
-                    "{\"title\":\"%s\",\"status\":%d,\"detail\":\"%s\",\"instance\":\"STOMP\"}",
+                    "{\"errorCode\":\"%s\",\"title\":\"%s\",\"status\":%d,\"detail\":\"%s\",\"instance\":\"STOMP\"}",
+                    exceptionCode.getErrorCode(),
                     exceptionCode.getTitle(),
                     exceptionCode.getHttpStatus().value(),
                     exceptionCode.getDetail()

--- a/src/main/java/com/team/cops_and_robbers/common/swagger/SwaggerConfig.java
+++ b/src/main/java/com/team/cops_and_robbers/common/swagger/SwaggerConfig.java
@@ -30,41 +30,13 @@ public class SwaggerConfig {
 
         Info info = new Info()
                 .title("👮 경찰과 도둑 API 🥷")
-                .version("2.7.0")
+                .version("2.8.0")
                 .description("""
-                        ## v2.7.0 업데이트 내역
-
-                        ### ✅ 신규 API
-                        - 게임 푸시 알림 수신 동의 여부 조회 API 추가 (GET /api/user/agreements/game-push)
-                        - 게임 푸시 알림 수신 동의 여부 업데이트 API 추가 (PUT /api/user/agreements/game-push)
+                        ## v2.8.0 업데이트 내역
 
                         ### 🛠 변경 및 수정
-                        - 이전 API에 운동장 -> 플레이그라운드로 스웨거 명세 수정
-                        - 게임 알림에 이모지 제거
-                        - timezone suffix 누락 버그 수정: 아래 필드들이 +09:00 포함된 형식으로 변경됨
-                          - GET /api/games/{gameId} → gameStartTime
-                          - POST /api/games → createdAt
-                          - GET /api/notices, GET /api/notices/{noticeId} → createdAt, updatedAt
-
-                        ## v2.6.0 업데이트 내역
-
-                        ### ✅ 신규 API
-
-                        **게임 상태 조회** `GET /api/games/{gameId}/state`
-                        - 앱 재접속·소켓 재연결 시 게임 화면 복원에 사용 (기존 도둑 위치 조회 API를 대체)
-                        - 응답: 마지막 위치 공개 주기의 생존 도둑 위치 스냅샷 + 전체 참여자 팀·상태
-                        - `robberLocations` 반환 조건
-                          - 경찰 대기 시간 중 (POLICE_WAITING): 도둑 위치 빈 배열 — 경찰·도둑 모두 위치 비공개
-                          - 경찰 출동 후 첫 공개 주기 전: 도둑 위치 빈 배열
-                          - 첫 도둑 위치 공개 이후: 생존 도둑 위치 목록 (JAILED 도둑 제외)
-                        - 자세한 내용은 해당 API 항목을 확인하세요.
-
-                        ### ⚠️ Deprecated API
-
-                        **도둑 위치 조회** `GET /api/games/{gameId}/robbers/location`
-                        - 기존 강제 종료 후 재접속 시 위치 공개 버그는 해결된 상태입니다.
-                        - `state` API의 `robberLocations` 필드로 동일한 데이터를 제공받을 수 있습니다 (위 `state` API로 마이그레이션 필요)
-                        - 현재는 호출 가능하나, 프론트 마이그레이션 완료 후 삭제됩니다
+                        - 모든 에러 응답에 `errorCode` 필드 추가 (예: `INVALID_INVITE_CODE`, `GAME_NOT_FOUND`)
+                        - STOMP 에러 응답에도 동일하게 적용
                         """);
 
         return new OpenAPI()

--- a/src/main/java/com/team/cops_and_robbers/common/swagger/SwaggerOperationCustomizer.java
+++ b/src/main/java/com/team/cops_and_robbers/common/swagger/SwaggerOperationCustomizer.java
@@ -87,6 +87,7 @@ public class SwaggerOperationCustomizer implements OperationCustomizer {
 
     private Example toExample(ExceptionCode code, String pathPattern) {
         Map<String, Object> value = new LinkedHashMap<>();
+        value.put("errorCode", code.getErrorCode());
         value.put("title", code.getTitle());
         value.put("status", code.getHttpStatus().value());
         value.put("detail", code.getDetail());


### PR DESCRIPTION
## 📎 Issue 번호

<!-- PR과 연관된 이슈의 번호를 작성해주세요.
PR 머지 시 close 되어야 하는 이슈의 경우 이슈 번호 앞에 `closed` 키워드를 붙여주세요.

ex) `closed #2` -->

- closed #104

## ✨ 작업 내용

<!-- 핵심적으로 변경된 사항들을 간략하게 서술해주세요. -> 예시: S3 업로드 기능 추가 -->

기존에 프론트엔드는 API 실패 응답의 detail 필드를 직접 UI에 보여주고 있었습니다. 

앱에 다국어(영어,일본어) 지원이 추가되면서 detail이 한글로 하드코딩되어 있어 한글 문구가 그대로 노출되고 있습니다. 프론트에서 에러를 식별할 수 있도록 응답 필드에 errorCode를 추가하여 국제화 처리를 할 수 있도록 작업했습니다!

```json
// 변경 전 응답
{
"title": "잘못된 초대 코드",
"status": 400,
"detail": "유효하지 않은 초대 코드입니다.",
"instance": "/api/games/1/participants"
}
```

```json
// 변경 후 응답
{
"errorCode": "INVALID_INVITE_CODE",
"title": "잘못된 초대 코드",
"status": 400,
"detail": "유효하지 않은 초대 코드입니다.",
"instance": "/api/games/1/participants"
}
```

- STOMP 에러 응답에도 동일하게 적용
- 스웨거 버전 업데이트

## ✅ 테스트

- [X] 수동 테스트 완료
- [X] 테스트 코드 완료