### PR TITLE
feat: 인게임 퇴장 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ build/
 postgres-data/
 redis-data/
 src/main/resources/firebase-key.json
+docs/
+
 
 ### STS ###
 .apt_generated

--- a/src/main/java/com/team/cops_and_robbers/common/config/WebSocketConfig.java
+++ b/src/main/java/com/team/cops_and_robbers/common/config/WebSocketConfig.java
@@ -32,7 +32,8 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
      */
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
-        registry.enableSimpleBroker(SUBSCRIBE_PATH_PREFIX);
+        registry.enableSimpleBroker(SUBSCRIBE_PATH_PREFIX)
+                .setHeartbeatValue(new long[]{10000, 10000});
         registry.setApplicationDestinationPrefixes(PUBLISH_PATH_PREFIX);
     }
 

--- a/src/main/java/com/team/cops_and_robbers/common/config/WebSocketConfig.java
+++ b/src/main/java/com/team/cops_and_robbers/common/config/WebSocketConfig.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
@@ -32,8 +33,14 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
      */
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(1);
+        scheduler.setThreadNamePrefix("ws-heartbeat-");
+        scheduler.initialize();
+
         registry.enableSimpleBroker(SUBSCRIBE_PATH_PREFIX)
-                .setHeartbeatValue(new long[]{10000, 10000});
+                .setHeartbeatValue(new long[]{10000, 10000})
+                .setTaskScheduler(scheduler);
         registry.setApplicationDestinationPrefixes(PUBLISH_PATH_PREFIX);
     }
 

--- a/src/main/java/com/team/cops_and_robbers/common/swagger/SwaggerConfig.java
+++ b/src/main/java/com/team/cops_and_robbers/common/swagger/SwaggerConfig.java
@@ -30,15 +30,13 @@ public class SwaggerConfig {
 
         Info info = new Info()
                 .title("👮 경찰과 도둑 API 🥷")
-                .version("2.8.0")
+                .version("2.10.0")
                 .description("""
-                        ## v2.9.0 업데이트 내역
+                        ## v2.10.0 업데이트 내역
 
                         ### 🛠 변경 및 수정
-                        - 모든 에러 응답에 `errorCode` 필드 추가 (예: `INVALID_INVITE_CODE`, `GAME_NOT_FOUND`)
-                        - STOMP 에러 응답에도 동일하게 적용
-                        - USER_NOT_FOUND 응답 오타 수정
-                        - 핑 기능 추가 (노션 명세 "핑" 문서 참고)
+                        - DELETE /api/games/{gameId}/leave API 인게임 중도 퇴장 분기처리 추가
+                          (제세한 변경 내용은 해당 항목 참고)
                         """);
 
         return new OpenAPI()

--- a/src/main/java/com/team/cops_and_robbers/game/participant/application/GameParticipantService.java
+++ b/src/main/java/com/team/cops_and_robbers/game/participant/application/GameParticipantService.java
@@ -12,10 +12,16 @@ import com.team.cops_and_robbers.game.participant.application.dto.result.GameJoi
 import com.team.cops_and_robbers.game.participant.application.dto.result.GameLeaveResult;
 import com.team.cops_and_robbers.game.participant.application.dto.result.GameParticipantListResult;
 import com.team.cops_and_robbers.game.participant.domain.GameParticipant;
+import com.team.cops_and_robbers.game.participant.domain.ParticipantStatus;
+import com.team.cops_and_robbers.game.participant.domain.Team;
 import com.team.cops_and_robbers.game.participant.exception.GameParticipantException;
 import com.team.cops_and_robbers.game.participant.repository.GameParticipantRepository;
+import com.team.cops_and_robbers.play.common.repository.InGameParticipantCacheRepository;
 import com.team.cops_and_robbers.play.lobby.application.LobbyEventFactory;
 import com.team.cops_and_robbers.play.lobby.domain.LobbyEvent;
+import com.team.cops_and_robbers.play.system.application.GameTerminationService;
+import com.team.cops_and_robbers.play.system.application.SystemEventFactory;
+import com.team.cops_and_robbers.play.system.domain.SystemEvent;
 import com.team.cops_and_robbers.user.domain.User;
 import com.team.cops_and_robbers.user.exception.UserException;
 import com.team.cops_and_robbers.user.repository.UserRepository;
@@ -37,9 +43,12 @@ public class GameParticipantService {
     private final UserRepository userRepository;
     private final GameAreaRepository gameAreaRepository;
     private final GameParticipantRepository gameParticipantRepository;
+    private final InGameParticipantCacheRepository inGameParticipantCacheRepository;
 
     private final ApplicationEventPublisher eventPublisher;
     private final LobbyEventFactory lobbyEventFactory;
+    private final SystemEventFactory systemEventFactory;
+    private final GameTerminationService gameTerminationService;
 
     @Transactional
     public GameJoinResult joinGame(GameJoinCommand command) {
@@ -83,46 +92,108 @@ public class GameParticipantService {
         return user;
     }
 
+    /**
+     * 1. 게임방 나가기 기능을 처리합니다.
+     * - 로비 상태 일떄 (게임 시작 x)
+     * - 게임 중인 상태일때
+     */
     @Transactional
     public GameLeaveResult leaveGame(GameLeaveCommand command) {
         GameParticipant participant = gameParticipantRepository.getByGameIdAndUserId(command.gameId(), command.userId());
-        validateLeavable(participant);
+        Game game = participant.getGame();
 
+        if (game.isInProgress()) {
+            return leaveFromInGame(participant, command.gameId(), command.userId());
+        }
+        return leaveFromLobby(participant, command.gameId(), command.userId());
+    }
+
+    /**
+     * 1-1. 로비 상태의 나가기를 처리합니다. (게임 중 x)
+     * - 로비에 남은 인원이 없을땐 게임방을 삭제 합니다.
+     * - 방장이 퇴장 할땐 방장을 넘겨준 뒤 퇴장합니다.
+     */
+    private GameLeaveResult leaveFromLobby(GameParticipant participant, Long gameId, Long userId) {
         boolean wasHost = participant.isHost();
-
         Long exitedParticipantId = participant.getId();
         int maxCount = participant.getGame().getMaxParticipants();
 
         gameParticipantRepository.delete(participant);
 
-        // 1. 마지막 사람이 나갈 경우 방을 삭제한다.
-        int remainingCount = gameParticipantRepository.countByGameId(command.gameId());
+        int remainingCount = gameParticipantRepository.countByGameId(gameId);
         if (remainingCount == NO_PARTICIPANTS) {
-            gameAreaRepository.deleteByGameId(command.gameId());
-            gameRepository.deleteById(command.gameId());
-
-            return GameLeaveResult.from(command.userId(), NO_PARTICIPANTS);
+            gameAreaRepository.deleteByGameId(gameId);
+            gameRepository.deleteById(gameId);
+            return GameLeaveResult.from(userId, NO_PARTICIPANTS);
         }
 
-        // 2. 방장이 나갈 경우 방장 다음 들어온 사람에게 방장을 위임한다.
-        if (wasHost) {
-            GameParticipant newHost = gameParticipantRepository.getNextParticipant(command.gameId());
-            newHost.promoteToHost();
+        transferHostIfNeeded(wasHost, gameId);
 
-            LobbyEvent hostEvent = lobbyEventFactory.createHostChangedEvent(command.gameId(), newHost);
-            eventPublisher.publishEvent(hostEvent);
-        }
-
-        LobbyEvent exitEvent = lobbyEventFactory.createExitEvent(command.gameId(), exitedParticipantId, remainingCount, maxCount);
+        LobbyEvent exitEvent = lobbyEventFactory.createExitEvent(gameId, exitedParticipantId, remainingCount, maxCount);
         eventPublisher.publishEvent(exitEvent);
 
-        return GameLeaveResult.from(command.userId(), remainingCount);
+        return GameLeaveResult.from(userId, remainingCount);
     }
 
-    private void validateLeavable(GameParticipant participant) {
-        if (!participant.isWaiting()) {
-            throw new ApplicationException(GameParticipantException.CANNOT_LEAVE_DURING_GAME);
+    /**
+     * 1-2. 인게임 중 나가기를 처리합니다.
+     * - 경찰 퇴장
+     *      - 마지막 경찰이면 도둑 팀 승리로 게임 종료 (POLICE_FORFEITED)
+     *      - 경찰이 남아있으면 PLAYER_LEFT 이벤트 발행
+     * - 도둑 퇴장
+     *      - ALIVE 상태이고 마지막 생존 도둑이면 경찰 팀 승리로 게임 종료 (ROBBER_FORFEITED)
+     *      - JAILED 상태이거나 생존 도둑이 남아있으면 PLAYER_LEFT 이벤트 발행
+     */
+    private GameLeaveResult leaveFromInGame(GameParticipant participant, Long gameId, Long userId) {
+        Team team = participant.getTeam();
+        ParticipantStatus status = participant.getStatus();
+        boolean wasHost = participant.isHost();
+
+        SystemEvent playerLeftEvent = systemEventFactory.createPlayerLeftEvent(gameId, participant);
+        removeParticipant(gameId, participant);
+
+        int remainingCount = gameParticipantRepository.countByGameId(gameId);
+
+        transferHostIfNeeded(wasHost && remainingCount > NO_PARTICIPANTS, gameId);
+
+        if (tryEndGameByForfeit(gameId, team, status)) {
+            return GameLeaveResult.from(userId, remainingCount);
         }
+
+        eventPublisher.publishEvent(playerLeftEvent);
+        return GameLeaveResult.from(userId, remainingCount);
+    }
+
+    private void transferHostIfNeeded(boolean wasHost, Long gameId) {
+        if (!wasHost) return;
+        GameParticipant newHost = gameParticipantRepository.getNextParticipant(gameId);
+        newHost.promoteToHost();
+        eventPublisher.publishEvent(lobbyEventFactory.createHostChangedEvent(gameId, newHost));
+    }
+
+    private boolean tryEndGameByForfeit(Long gameId, Team team, ParticipantStatus status) {
+        if (team == Team.POLICE && isLastPolice(gameId)) {
+            gameTerminationService.endGameByPoliceForfeited(gameId);
+            return true;
+        }
+        if (team == Team.ROBBER && status == ParticipantStatus.ALIVE && isLastAliveRobber(gameId)) {
+            gameTerminationService.endGameByRobberForfeited(gameId);
+            return true;
+        }
+        return false;
+    }
+
+    private void removeParticipant(Long gameId, GameParticipant participant) {
+        inGameParticipantCacheRepository.deleteByParticipantId(gameId, participant.getId());
+        gameParticipantRepository.delete(participant);
+    }
+
+    private boolean isLastPolice(Long gameId) {
+        return gameParticipantRepository.countByGameIdAndTeam(gameId, Team.POLICE) == NO_PARTICIPANTS;
+    }
+
+    private boolean isLastAliveRobber(Long gameId) {
+        return gameParticipantRepository.countByGameIdAndRobberStatus(gameId, ParticipantStatus.ALIVE) == NO_PARTICIPANTS;
     }
 
     public GameParticipantListResult getParticipantList(GameParticipantListCommand command) {

--- a/src/main/java/com/team/cops_and_robbers/game/participant/application/GameParticipantService.java
+++ b/src/main/java/com/team/cops_and_robbers/game/participant/application/GameParticipantService.java
@@ -156,11 +156,9 @@ public class GameParticipantService {
 
         transferHostIfNeeded(wasHost && remainingCount > NO_PARTICIPANTS, gameId);
 
-        if (tryEndGameByForfeit(gameId, team, status)) {
-            return GameLeaveResult.from(userId, remainingCount);
-        }
-
         eventPublisher.publishEvent(playerLeftEvent);
+
+        tryEndGameByForfeit(gameId, team, status);
         return GameLeaveResult.from(userId, remainingCount);
     }
 

--- a/src/main/java/com/team/cops_and_robbers/game/participant/domain/Team.java
+++ b/src/main/java/com/team/cops_and_robbers/game/participant/domain/Team.java
@@ -3,10 +3,19 @@ package com.team.cops_and_robbers.game.participant.domain;
 import java.util.concurrent.ThreadLocalRandom;
 
 public enum Team {
-    POLICE,
-    ROBBER;
+    POLICE("경찰"),
+    ROBBER("도둑");
 
     private static final Team[] VALUES = values();
+    private final String displayName;
+
+    Team(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
 
     public static Team getRandomTeam() {
         int randomIndex = ThreadLocalRandom.current().nextInt(VALUES.length);

--- a/src/main/java/com/team/cops_and_robbers/game/participant/presentation/GameParticipantControllerDocs.java
+++ b/src/main/java/com/team/cops_and_robbers/game/participant/presentation/GameParticipantControllerDocs.java
@@ -83,7 +83,10 @@ public interface GameParticipantControllerDocs {
                     **[PLAYER_LEFT 이벤트 페이로드]**
                     ```json
                     {
+                      "eventId": "550e8400-e29b-41d4-a716-446655440000",
+                      "gameId": 1,
                       "type": "PLAYER_LEFT",
+                      "timestamp": "2026-06-15T10:00:00+09:00",
                       "data": {
                         "participantId": 42,
                         "nickname": "닉네임",
@@ -95,7 +98,10 @@ public interface GameParticipantControllerDocs {
                     **[GAME_OVER 이벤트 페이로드]**
                     ```json
                     {
+                      "eventId": "550e8400-e29b-41d4-a716-446655440001",
+                      "gameId": 1,
                       "type": "GAME_OVER",
+                      "timestamp": "2026-06-15T10:00:05+09:00",
                       "data": {
                         "gameResultId": 1,
                         "winnerTeam": "POLICE 또는 ROBBER",

--- a/src/main/java/com/team/cops_and_robbers/game/participant/presentation/GameParticipantControllerDocs.java
+++ b/src/main/java/com/team/cops_and_robbers/game/participant/presentation/GameParticipantControllerDocs.java
@@ -38,7 +38,79 @@ public interface GameParticipantControllerDocs {
     );
 
     @Operation(summary = "게임 방 퇴장",
-            description = "현재 참여 중인 게임 방에서 퇴장합니다. 방장이 퇴장하는 경우 가장 먼저 참여한 참여자에게 방장 권한이 이전됩니다. 마지막 참여자가 퇴장하면 게임 방이 자동으로 삭제됩니다."
+            description = """
+                    게임 상태(로비 / 인게임)에 따라 퇴장 처리가 다르게 동작합니다.
+
+                    ---
+
+                    **[로비 상태 (WAITING)]**
+
+                    - 방장이 퇴장하면 가장 먼저 참여한 참여자에게 방장이 이전됩니다.
+                      → `/subscribe/game/{gameId}/lobby` 채널로 `HOST_CHANGED` 이벤트 수신
+                    - 마지막 참여자가 퇴장하면 게임 방이 삭제됩니다. (이벤트 없음)
+                    - 그 외 일반 퇴장: `/subscribe/game/{gameId}/lobby` 채널로 `EXIT` 이벤트 수신
+
+                    ---
+
+                    **[인게임 상태 (IN_PROGRESS)]**
+
+                    퇴장자의 팀과 상태에 따라 아래 네 가지 케이스로 분기됩니다.
+
+                    ■ 경찰 퇴장 & 경찰이 아직 남아 있는 경우
+                    → `/subscribe/game/{gameId}/system` 채널로 `PLAYER_LEFT` 이벤트 수신
+
+                    ■ 경찰 퇴장 & 마지막 경찰인 경우 (도둑팀 몰수(forfeit) 승리)
+                    → `/subscribe/game/{gameId}/system` 채널로 `GAME_OVER` 이벤트 수신
+                    ```json
+                    { "winnerTeam": "ROBBER", "reason": "POLICE_FORFEITED" }
+                    ```
+
+                    ■ 생존(ALIVE) 도둑 퇴장 & 생존 도둑이 아직 남아 있는 경우
+                    → `/subscribe/game/{gameId}/system` 채널로 `PLAYER_LEFT` 이벤트 수신
+
+                    ■ 생존(ALIVE) 도둑 퇴장 & 마지막 생존 도둑인 경우 (경찰팀 forfeit 승리)
+                    → `/subscribe/game/{gameId}/system` 채널로 `GAME_OVER` 이벤트 수신
+                    ```json
+                    { "winnerTeam": "POLICE", "reason": "ROBBER_FORFEITED" }
+                    ```
+
+                    ■ JAILED 도둑 퇴장 (게임 종료 조건 무관)
+                    → `/subscribe/game/{gameId}/system` 채널로 `PLAYER_LEFT` 이벤트 수신
+                    (JAILED 상태의 도둑은 생존 도둑 카운트에 포함되지 않으므로 forfeit 조건을 체크하지 않습니다.)
+
+                    ---
+
+                    **[PLAYER_LEFT 이벤트 페이로드]**
+                    ```json
+                    {
+                      "type": "PLAYER_LEFT",
+                      "data": {
+                        "participantId": 42,
+                        "nickname": "닉네임",
+                        "team": "POLICE 또는 ROBBER"
+                      }
+                    }
+                    ```
+
+                    **[GAME_OVER 이벤트 페이로드]**
+                    ```json
+                    {
+                      "type": "GAME_OVER",
+                      "data": {
+                        "gameResultId": 1,
+                        "winnerTeam": "POLICE 또는 ROBBER",
+                        "reason": "POLICE_FORFEITED 또는 ROBBER_FORFEITED"
+                      }
+                    }
+                    ```
+
+                    ---
+
+                    **[방장 위임]**
+
+                    방장이 퇴장하는 경우, 게임 상태(로비/인게임)와 무관하게 다음 참여자에게 방장이 이전됩니다.
+                    → `/subscribe/game/{gameId}/lobby` 채널로 `HOST_CHANGED` 이벤트 추가 수신
+                    """
     )
     @ApiErrorCode(value = GameException.class, codes = {"GAME_NOT_FOUND"})
     @ApiErrorCode(value = GameParticipantException.class, codes = {"PARTICIPANT_NOT_FOUND"})

--- a/src/main/java/com/team/cops_and_robbers/history/domain/GameEndReason.java
+++ b/src/main/java/com/team/cops_and_robbers/history/domain/GameEndReason.java
@@ -1,5 +1,5 @@
 package com.team.cops_and_robbers.history.domain;
 
 public enum GameEndReason {
-    ALL_ARRESTED, TIME_OVER
+    ALL_ARRESTED, TIME_OVER, POLICE_FORFEITED, ROBBER_FORFEITED
 }

--- a/src/main/java/com/team/cops_and_robbers/play/common/repository/InGameParticipantCacheRepository.java
+++ b/src/main/java/com/team/cops_and_robbers/play/common/repository/InGameParticipantCacheRepository.java
@@ -50,6 +50,10 @@ public class InGameParticipantCacheRepository {
         return Optional.of(objectMapper.convertValue(value, InGameParticipantCache.class));
     }
 
+    public void deleteByParticipantId(Long gameId, Long participantId) {
+        redisTemplate.opsForHash().delete(key(gameId), field(participantId));
+    }
+
     public void deleteAllByGameId(Long gameId) {
         redisTemplate.delete(key(gameId));
     }

--- a/src/main/java/com/team/cops_and_robbers/play/notification/application/GameFcmNotifier.java
+++ b/src/main/java/com/team/cops_and_robbers/play/notification/application/GameFcmNotifier.java
@@ -60,7 +60,7 @@ public class GameFcmNotifier {
             case POLICE_MOVE_START -> new FcmPayload("경찰 이동 시작!", "경찰이 이동을 시작했습니다!", data);
             case PLAYER_LEFT -> {
                 SystemEventData.PlayerLeftData playerLeft = (SystemEventData.PlayerLeftData) event.data();
-                yield new FcmPayload(playerLeft.team().getDisplayName() + " 참가자 퇴장", playerLeft.nickname() + "이(가) 게임에서 퇴장했습니다.", data);
+                yield new FcmPayload(playerLeft.team().getDisplayName() + " 참가자 퇴장", playerLeft.nickname() + "님이 게임에서 퇴장했습니다.", data);
             }
         };
     }

--- a/src/main/java/com/team/cops_and_robbers/play/notification/application/GameFcmNotifier.java
+++ b/src/main/java/com/team/cops_and_robbers/play/notification/application/GameFcmNotifier.java
@@ -5,6 +5,7 @@ import com.team.cops_and_robbers.common.fcm.FcmService;
 import com.team.cops_and_robbers.play.common.domain.InGameParticipantCache;
 import com.team.cops_and_robbers.play.common.repository.InGameParticipantCacheRepository;
 import com.team.cops_and_robbers.play.system.domain.SystemEvent;
+import com.team.cops_and_robbers.play.system.domain.SystemEventData;
 import com.team.cops_and_robbers.play.system.domain.SystemEventType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -33,7 +34,7 @@ public class GameFcmNotifier {
                 return CompletableFuture.completedFuture(null);
             }
 
-            FcmPayload payload = resolveSystemPayload(event.type(), event.gameId());
+            FcmPayload payload = resolveSystemPayload(event);
             fcmService.send(new FcmMessage(tokens, payload.title(), payload.body(), payload.data()));
         } catch (Exception e) {
             log.error("[FCM] Async send failed | gameId={}, type={}", event.gameId(), event.type(), e);
@@ -48,14 +49,19 @@ public class GameFcmNotifier {
                 .toList();
     }
 
-    private FcmPayload resolveSystemPayload(SystemEventType type, Long gameId) {
-        Map<String, String> data = Map.of("type", type.name(), "gameId", String.valueOf(gameId));
+    private FcmPayload resolveSystemPayload(SystemEvent event) {
+        SystemEventType type = event.type();
+        Map<String, String> data = Map.of("type", type.name(), "gameId", String.valueOf(event.gameId()));
         return switch (type) {
             case ARREST -> new FcmPayload("도둑 체포!", "도둑이 체포되었습니다.", data);
             case ESCAPE -> new FcmPayload("도둑 탈옥!", "도둑이 감옥에서 탈옥했습니다!", data);
             case GAME_OVER -> new FcmPayload("게임 종료", "게임이 종료되었습니다. 결과를 확인하세요!", data);
             case ROBBER_LOCATION_REVEAL -> new FcmPayload("도둑 위치 공개!", "도둑의 현재 위치가 공개되었습니다!", data);
             case POLICE_MOVE_START -> new FcmPayload("경찰 이동 시작!", "경찰이 이동을 시작했습니다!", data);
+            case PLAYER_LEFT -> {
+                SystemEventData.PlayerLeftData playerLeft = (SystemEventData.PlayerLeftData) event.data();
+                yield new FcmPayload(playerLeft.team().getDisplayName() + " 참가자 퇴장", playerLeft.nickname() + "이(가) 게임에서 퇴장했습니다.", data);
+            }
         };
     }
 

--- a/src/main/java/com/team/cops_and_robbers/play/system/application/GameTerminationService.java
+++ b/src/main/java/com/team/cops_and_robbers/play/system/application/GameTerminationService.java
@@ -48,6 +48,28 @@ public class GameTerminationService {
         endGame(game, Team.ROBBER, GameEndReason.TIME_OVER);
     }
 
+    @Transactional
+    public void endGameByPoliceForfeited(Long gameId) {
+        Game game = gameRepository.getByGameId(gameId);
+
+        if (!game.isInProgress()) {
+            log.info("[GameTermination] Already finished game (GameId: {}, request: POLICE_FORFEITED)", gameId);
+            return;
+        }
+        endGame(game, Team.ROBBER, GameEndReason.POLICE_FORFEITED);
+    }
+
+    @Transactional
+    public void endGameByRobberForfeited(Long gameId) {
+        Game game = gameRepository.getByGameId(gameId);
+
+        if (!game.isInProgress()) {
+            log.info("[GameTermination] Already finished game (GameId: {}, request: ROBBER_FORFEITED)", gameId);
+            return;
+        }
+        endGame(game, Team.POLICE, GameEndReason.ROBBER_FORFEITED);
+    }
+
     private void endGame(Game game, Team winner, GameEndReason reason) {
         GameResult result = gameResultService.recordGameResult(game, winner, reason);
         game.resetForNextRound();

--- a/src/main/java/com/team/cops_and_robbers/play/system/application/SystemEventFactory.java
+++ b/src/main/java/com/team/cops_and_robbers/play/system/application/SystemEventFactory.java
@@ -37,4 +37,9 @@ public class SystemEventFactory {
         SystemEventData.GameEndData data = SystemEventData.GameEndData.of(gameResultId, winnerTeam, reason);
         return SystemEvent.of(gameId, SystemEventType.GAME_OVER, data);
     }
+
+    public SystemEvent createPlayerLeftEvent(Long gameId, GameParticipant participant) {
+        SystemEventData.PlayerLeftData data = SystemEventData.PlayerLeftData.of(participant);
+        return SystemEvent.of(gameId, SystemEventType.PLAYER_LEFT, data);
+    }
 }

--- a/src/main/java/com/team/cops_and_robbers/play/system/domain/SystemEventData.java
+++ b/src/main/java/com/team/cops_and_robbers/play/system/domain/SystemEventData.java
@@ -12,7 +12,8 @@ public sealed interface SystemEventData permits
         SystemEventData.RobberLocationRevealData,
         SystemEventData.ArrestData,
         SystemEventData.EscapeData,
-        SystemEventData.GameEndData {
+        SystemEventData.GameEndData,
+        SystemEventData.PlayerLeftData {
 
     record SystemParticipantInfo(Long participantId, String nickname, ParticipantStatus status) {
         public static SystemParticipantInfo from(GameParticipant participant) {
@@ -58,6 +59,16 @@ public sealed interface SystemEventData permits
     record GameEndData(Long gameResultId, Team winnerTeam, GameEndReason reason) implements SystemEventData {
         public static GameEndData of(Long gameResultId, Team winnerTeam, GameEndReason reason) {
             return new GameEndData(gameResultId, winnerTeam, reason);
+        }
+    }
+
+    record PlayerLeftData(Long participantId, String nickname, Team team) implements SystemEventData {
+        public static PlayerLeftData of(GameParticipant participant) {
+            return new PlayerLeftData(
+                    participant.getId(),
+                    participant.getUser().getNickname(),
+                    participant.getTeam()
+            );
         }
     }
 }

--- a/src/main/java/com/team/cops_and_robbers/play/system/domain/SystemEventType.java
+++ b/src/main/java/com/team/cops_and_robbers/play/system/domain/SystemEventType.java
@@ -5,5 +5,6 @@ public enum SystemEventType {
     ROBBER_LOCATION_REVEAL,
     ARREST,
     ESCAPE,
-    GAME_OVER
+    GAME_OVER,
+    PLAYER_LEFT
 }

--- a/src/test/java/com/team/cops_and_robbers/common/ControllerTest.java
+++ b/src/test/java/com/team/cops_and_robbers/common/ControllerTest.java
@@ -148,6 +148,14 @@ public abstract class ControllerTest {
         return gameParticipantRepository.save(GameParticipantFixture.ALIVE_ROBBER(game, user));
     }
 
+    protected GameParticipant givenJailedRobber(Game game, User user) {
+        return gameParticipantRepository.save(GameParticipantFixture.JAILED_ROBBER(game, user));
+    }
+
+    protected GameParticipant givenInGameHost(Game game, User user) {
+        return gameParticipantRepository.save(GameParticipantFixture.HOST_WAITING_POLICE(game, user));
+    }
+
     protected GameParticipant givenWaitingPolice(Game game, User user) {
         GameParticipant participant = gameParticipantRepository.getByGameIdAndUserId(game.getId(), user.getId());
         participant.updateStatus(ParticipantStatus.POLICE_WAITING);

--- a/src/test/java/com/team/cops_and_robbers/common/fixture/GameParticipantFixture.java
+++ b/src/test/java/com/team/cops_and_robbers/common/fixture/GameParticipantFixture.java
@@ -106,4 +106,15 @@ public class GameParticipantFixture {
                 .isHost(false)
                 .build();
     }
+
+    public static GameParticipant HOST_WAITING_POLICE(Game game, User user) {
+        return GameParticipant.builder()
+                .game(game)
+                .user(user)
+                .team(Team.POLICE)
+                .status(ParticipantStatus.POLICE_WAITING)
+                .isReady(true)
+                .isHost(true)
+                .build();
+    }
 }

--- a/src/test/java/com/team/cops_and_robbers/game/participant/application/GameParticipantServiceTest.java
+++ b/src/test/java/com/team/cops_and_robbers/game/participant/application/GameParticipantServiceTest.java
@@ -13,8 +13,14 @@ import com.team.cops_and_robbers.game.participant.application.dto.result.GameLea
 import com.team.cops_and_robbers.game.participant.application.dto.result.GameParticipantListResult;
 import com.team.cops_and_robbers.game.participant.domain.GameParticipant;
 import com.team.cops_and_robbers.game.participant.exception.GameParticipantException;
+import com.team.cops_and_robbers.game.participant.domain.ParticipantStatus;
+import com.team.cops_and_robbers.game.participant.domain.Team;
+import com.team.cops_and_robbers.play.common.repository.InGameParticipantCacheRepository;
 import com.team.cops_and_robbers.play.lobby.application.LobbyEventFactory;
 import com.team.cops_and_robbers.play.lobby.domain.LobbyEvent;
+import com.team.cops_and_robbers.play.system.application.GameTerminationService;
+import com.team.cops_and_robbers.play.system.application.SystemEventFactory;
+import com.team.cops_and_robbers.play.system.domain.SystemEvent;
 import com.team.cops_and_robbers.user.domain.User;
 import com.team.cops_and_robbers.user.exception.UserException;
 import org.junit.jupiter.api.BeforeEach;
@@ -38,6 +44,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 
@@ -51,6 +58,15 @@ class GameParticipantServiceTest extends ServiceUnitTest {
 
     @Mock
     private ApplicationEventPublisher eventPublisher;
+
+    @Mock
+    private InGameParticipantCacheRepository inGameParticipantCacheRepository;
+
+    @Mock
+    private SystemEventFactory systemEventFactory;
+
+    @Mock
+    private GameTerminationService gameTerminationService;
 
     @Mock
     private LobbyEvent lobbyEvent;
@@ -220,19 +236,120 @@ class GameParticipantServiceTest extends ServiceUnitTest {
             then(eventPublisher).should(times(2)).publishEvent(lobbyEvent);
         }
 
+    }
+
+    @Nested
+    @DisplayName("인게임 중도 퇴장")
+    class leaveFromInGame {
+
         @Test
-        void 참가자의_상태가_WAITING이_아니면_예외가_발생한다() {
+        void 경찰이_퇴장하고_경찰이_남아있으면_PLAYER_LEFT_이벤트를_발행한다() {
             // given
-            GameParticipant aliveParticipant = ALIVE_POLICE(waitingGame, user);
-            GameLeaveCommand command = createGameLeaveCommand(user.getId(), waitingGame.getId());
+            GameLeaveCommand command = createGameLeaveCommand(user.getId(), TEST_GAME_ID);
+            given(gameParticipantRepository.getByGameIdAndUserId(TEST_GAME_ID, user.getId())).willReturn(policeParticipant);
+            given(gameParticipantRepository.countByGameId(TEST_GAME_ID)).willReturn(1);
+            given(gameParticipantRepository.countByGameIdAndTeam(TEST_GAME_ID, Team.POLICE)).willReturn(1);
+            given(systemEventFactory.createPlayerLeftEvent(any(), any())).willReturn(mock(SystemEvent.class));
 
-            given(gameParticipantRepository.getByGameIdAndUserId(waitingGame.getId(), user.getId()))
-                    .willReturn(aliveParticipant);
+            // when
+            gameParticipantService.leaveGame(command);
 
-            // when & then
-            assertThatThrownBy(() -> gameParticipantService.leaveGame(command))
-                    .isInstanceOf(ApplicationException.class)
-                    .hasMessageContaining(GameParticipantException.CANNOT_LEAVE_DURING_GAME.getDetail());
+            // then
+            then(inGameParticipantCacheRepository).should().deleteByParticipantId(any(), any());
+            then(gameTerminationService).should(never()).endGameByPoliceForfeited(any());
+            then(eventPublisher).should().publishEvent(any(SystemEvent.class));
+        }
+
+        @Test
+        void 마지막_경찰이_퇴장하면_POLICE_FORFEITED로_게임이_종료된다() {
+            // given
+            GameLeaveCommand command = createGameLeaveCommand(user.getId(), TEST_GAME_ID);
+            given(gameParticipantRepository.getByGameIdAndUserId(TEST_GAME_ID, user.getId())).willReturn(policeParticipant);
+            given(gameParticipantRepository.countByGameId(TEST_GAME_ID)).willReturn(0);
+            given(gameParticipantRepository.countByGameIdAndTeam(TEST_GAME_ID, Team.POLICE)).willReturn(0);
+            given(systemEventFactory.createPlayerLeftEvent(any(), any())).willReturn(mock(SystemEvent.class));
+
+            // when
+            gameParticipantService.leaveGame(command);
+
+            // then
+            then(gameTerminationService).should().endGameByPoliceForfeited(TEST_GAME_ID);
+            then(eventPublisher).should(never()).publishEvent(any(SystemEvent.class));
+        }
+
+        @Test
+        void ALIVE_도둑이_퇴장하고_생존_도둑이_남아있으면_PLAYER_LEFT_이벤트를_발행한다() {
+            // given
+            GameLeaveCommand command = createGameLeaveCommand(user2.getId(), TEST_GAME_ID);
+            given(gameParticipantRepository.getByGameIdAndUserId(TEST_GAME_ID, user2.getId())).willReturn(robberParticipant);
+            given(gameParticipantRepository.countByGameId(TEST_GAME_ID)).willReturn(1);
+            given(gameParticipantRepository.countByGameIdAndRobberStatus(TEST_GAME_ID, ParticipantStatus.ALIVE)).willReturn(1);
+            given(systemEventFactory.createPlayerLeftEvent(any(), any())).willReturn(mock(SystemEvent.class));
+
+            // when
+            gameParticipantService.leaveGame(command);
+
+            // then
+            then(gameTerminationService).should(never()).endGameByRobberForfeited(any());
+            then(eventPublisher).should().publishEvent(any(SystemEvent.class));
+        }
+
+        @Test
+        void 마지막_생존_도둑이_퇴장하면_ROBBER_FORFEITED로_게임이_종료된다() {
+            // given
+            GameLeaveCommand command = createGameLeaveCommand(user2.getId(), TEST_GAME_ID);
+            given(gameParticipantRepository.getByGameIdAndUserId(TEST_GAME_ID, user2.getId())).willReturn(robberParticipant);
+            given(gameParticipantRepository.countByGameId(TEST_GAME_ID)).willReturn(0);
+            given(gameParticipantRepository.countByGameIdAndRobberStatus(TEST_GAME_ID, ParticipantStatus.ALIVE)).willReturn(0);
+            given(systemEventFactory.createPlayerLeftEvent(any(), any())).willReturn(mock(SystemEvent.class));
+
+            // when
+            gameParticipantService.leaveGame(command);
+
+            // then
+            then(gameTerminationService).should().endGameByRobberForfeited(TEST_GAME_ID);
+            then(eventPublisher).should(never()).publishEvent(any(SystemEvent.class));
+        }
+
+        @Test
+        void JAILED_도둑이_퇴장하면_forfeit_조건_체크_없이_PLAYER_LEFT_이벤트를_발행한다() {
+            // given
+            GameParticipant jailedRobber = JAILED_ROBBER(inProgressGame, user);
+            GameLeaveCommand command = createGameLeaveCommand(user.getId(), TEST_GAME_ID);
+            given(gameParticipantRepository.getByGameIdAndUserId(TEST_GAME_ID, user.getId())).willReturn(jailedRobber);
+            given(gameParticipantRepository.countByGameId(TEST_GAME_ID)).willReturn(1);
+            given(systemEventFactory.createPlayerLeftEvent(any(), any())).willReturn(mock(SystemEvent.class));
+
+            // when
+            gameParticipantService.leaveGame(command);
+
+            // then
+            then(gameParticipantRepository).should(never()).countByGameIdAndTeam(any(), any());
+            then(gameParticipantRepository).should(never()).countByGameIdAndRobberStatus(any(), any());
+            then(gameTerminationService).should(never()).endGameByPoliceForfeited(any());
+            then(gameTerminationService).should(never()).endGameByRobberForfeited(any());
+            then(eventPublisher).should().publishEvent(any(SystemEvent.class));
+        }
+
+        @Test
+        void 방장이_인게임에서_퇴장하면_다음_참가자에게_방장이_위임된다() {
+            // given
+            GameParticipant hostPolice = HOST_WAITING_POLICE(inProgressGame, user);
+            GameLeaveCommand command = createGameLeaveCommand(user.getId(), TEST_GAME_ID);
+            given(gameParticipantRepository.getByGameIdAndUserId(TEST_GAME_ID, user.getId())).willReturn(hostPolice);
+            given(gameParticipantRepository.countByGameId(TEST_GAME_ID)).willReturn(1);
+            given(gameParticipantRepository.countByGameIdAndTeam(TEST_GAME_ID, Team.POLICE)).willReturn(1);
+            given(gameParticipantRepository.getNextParticipant(TEST_GAME_ID)).willReturn(robberParticipant);
+            given(lobbyEventFactory.createHostChangedEvent(any(), any())).willReturn(lobbyEvent);
+            given(systemEventFactory.createPlayerLeftEvent(any(), any())).willReturn(mock(SystemEvent.class));
+
+            // when
+            gameParticipantService.leaveGame(command);
+
+            // then
+            assertThat(robberParticipant.isHost()).isTrue();
+            then(eventPublisher).should().publishEvent(lobbyEvent);
+            then(eventPublisher).should().publishEvent(any(SystemEvent.class));
         }
     }
 

--- a/src/test/java/com/team/cops_and_robbers/game/participant/application/GameParticipantServiceTest.java
+++ b/src/test/java/com/team/cops_and_robbers/game/participant/application/GameParticipantServiceTest.java
@@ -274,7 +274,7 @@ class GameParticipantServiceTest extends ServiceUnitTest {
 
             // then
             then(gameTerminationService).should().endGameByPoliceForfeited(TEST_GAME_ID);
-            then(eventPublisher).should(never()).publishEvent(any(SystemEvent.class));
+            then(eventPublisher).should().publishEvent(any(SystemEvent.class));
         }
 
         @Test
@@ -308,7 +308,7 @@ class GameParticipantServiceTest extends ServiceUnitTest {
 
             // then
             then(gameTerminationService).should().endGameByRobberForfeited(TEST_GAME_ID);
-            then(eventPublisher).should(never()).publishEvent(any(SystemEvent.class));
+            then(eventPublisher).should().publishEvent(any(SystemEvent.class));
         }
 
         @Test

--- a/src/test/java/com/team/cops_and_robbers/game/participant/presentation/GameParticipantControllerTest.java
+++ b/src/test/java/com/team/cops_and_robbers/game/participant/presentation/GameParticipantControllerTest.java
@@ -1,6 +1,7 @@
 package com.team.cops_and_robbers.game.participant.presentation;
 
 import com.team.cops_and_robbers.common.ControllerTest;
+import com.team.cops_and_robbers.common.fixture.GameAreaFixture;
 import com.team.cops_and_robbers.common.fixture.GameFixture;
 import com.team.cops_and_robbers.common.fixture.UserFixture;
 import com.team.cops_and_robbers.game.game.domain.Game;
@@ -318,6 +319,183 @@ class GameParticipantControllerTest extends ControllerTest {
 
             // then
             assertThat(response.statusCode()).isEqualTo(HttpStatus.NOT_FOUND.value());
+        }
+    }
+
+    @Nested
+    @DisplayName("인게임 중 퇴장 API")
+    class LeaveFromInGame {
+
+        private Game inProgressGame;
+
+        @BeforeEach
+        void setUp() {
+            inProgressGame = gameRepository.save(GameFixture.IN_PROGRESS_GAME());
+            gameAreaRepository.save(GameAreaFixture.GAME_AREA(inProgressGame));
+        }
+
+        @Test
+        void 경찰이_퇴장하고_경찰이_남아있으면_성공_응답을_반환한다() {
+            // given
+            User police1 = givenUser("police1");
+            String police1Token = givenAccessToken(police1);
+            givenPolice(inProgressGame, police1);
+
+            User police2 = givenUser("police2");
+            givenPolice(inProgressGame, police2);
+
+            // when
+            ExtractableResponse<Response> response = authenticated(police1Token)
+                    .pathParam(GAME_ID_PARAM, inProgressGame.getId())
+                    .when()
+                    .delete(LEAVE_URL)
+                    .then()
+                    .extract();
+
+            // then
+            GameLeaveResponse result = response.as(GameLeaveResponse.class);
+            assertSoftly(softly -> {
+                softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+                softly.assertThat(result.leftUserId()).isEqualTo(police1.getId());
+                softly.assertThat(result.remainingCount()).isEqualTo(1);
+            });
+        }
+
+        @Test
+        void 마지막_경찰이_퇴장하면_게임이_종료된다() {
+            // given
+            User police = givenUser("police");
+            String policeToken = givenAccessToken(police);
+            givenPolice(inProgressGame, police);
+
+            User robber = givenUser("robber");
+            givenRobber(inProgressGame, robber);
+
+            // when
+            ExtractableResponse<Response> response = authenticated(policeToken)
+                    .pathParam(GAME_ID_PARAM, inProgressGame.getId())
+                    .when()
+                    .delete(LEAVE_URL)
+                    .then()
+                    .extract();
+
+            // then
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+            Game game = gameRepository.findById(inProgressGame.getId()).orElseThrow();
+            assertThat(game.isInProgress()).isFalse();
+        }
+
+        @Test
+        void ALIVE_도둑이_퇴장하고_생존_도둑이_남아있으면_성공_응답을_반환한다() {
+            // given
+            User police = givenUser("police");
+            givenPolice(inProgressGame, police);
+
+            User robber1 = givenUser("robber1");
+            String robber1Token = givenAccessToken(robber1);
+            givenRobber(inProgressGame, robber1);
+
+            User robber2 = givenUser("robber2");
+            givenRobber(inProgressGame, robber2);
+
+            // when
+            ExtractableResponse<Response> response = authenticated(robber1Token)
+                    .pathParam(GAME_ID_PARAM, inProgressGame.getId())
+                    .when()
+                    .delete(LEAVE_URL)
+                    .then()
+                    .extract();
+
+            // then
+            GameLeaveResponse result = response.as(GameLeaveResponse.class);
+            assertSoftly(softly -> {
+                softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+                softly.assertThat(result.leftUserId()).isEqualTo(robber1.getId());
+                softly.assertThat(result.remainingCount()).isEqualTo(2);
+            });
+        }
+
+        @Test
+        void 마지막_ALIVE_도둑이_퇴장하면_게임이_종료된다() {
+            // given
+            User police = givenUser("police");
+            givenPolice(inProgressGame, police);
+
+            User aliveRobber = givenUser("aliveRobber");
+            String aliveRobberToken = givenAccessToken(aliveRobber);
+            givenRobber(inProgressGame, aliveRobber);
+
+            User jailedRobber = givenUser("jailedRobber");
+            givenJailedRobber(inProgressGame, jailedRobber);
+
+            // when
+            ExtractableResponse<Response> response = authenticated(aliveRobberToken)
+                    .pathParam(GAME_ID_PARAM, inProgressGame.getId())
+                    .when()
+                    .delete(LEAVE_URL)
+                    .then()
+                    .extract();
+
+            // then
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+            Game game = gameRepository.findById(inProgressGame.getId()).orElseThrow();
+            assertThat(game.isInProgress()).isFalse();
+        }
+
+        @Test
+        void JAILED_도둑이_퇴장하면_게임이_종료되지_않는다() {
+            // given
+            User police = givenUser("police");
+            givenPolice(inProgressGame, police);
+
+            User aliveRobber = givenUser("aliveRobber");
+            givenRobber(inProgressGame, aliveRobber);
+
+            User jailedRobber = givenUser("jailedRobber");
+            String jailedRobberToken = givenAccessToken(jailedRobber);
+            givenJailedRobber(inProgressGame, jailedRobber);
+
+            // when
+            ExtractableResponse<Response> response = authenticated(jailedRobberToken)
+                    .pathParam(GAME_ID_PARAM, inProgressGame.getId())
+                    .when()
+                    .delete(LEAVE_URL)
+                    .then()
+                    .extract();
+
+            // then
+            GameLeaveResponse result = response.as(GameLeaveResponse.class);
+            assertSoftly(softly -> {
+                softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+                softly.assertThat(result.leftUserId()).isEqualTo(jailedRobber.getId());
+            });
+            Game game = gameRepository.findById(inProgressGame.getId()).orElseThrow();
+            assertThat(game.isInProgress()).isTrue();
+        }
+
+        @Test
+        void 방장이_인게임에서_퇴장하면_다음_참가자에게_방장이_위임된다() {
+            // given
+            User inGameHost = givenUser("inGameHost");
+            String inGameHostToken = givenAccessToken(inGameHost);
+            givenInGameHost(inProgressGame, inGameHost);
+
+            User guest = givenUser("inGameGuest");
+            givenPolice(inProgressGame, guest);
+
+            // when
+            ExtractableResponse<Response> response = authenticated(inGameHostToken)
+                    .pathParam(GAME_ID_PARAM, inProgressGame.getId())
+                    .when()
+                    .delete(LEAVE_URL)
+                    .then()
+                    .extract();
+
+            // then
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+            GameParticipant newHost = gameParticipantRepository.findByGameIdAndUserId(inProgressGame.getId(), guest.getId())
+                    .orElseThrow();
+            assertThat(newHost.isHost()).isTrue();
         }
     }
 


### PR DESCRIPTION
## 📎 Issue 번호
<!-- PR과 연관된 이슈의 번호를 작성해주세요.
PR 머지 시 close 되어야 하는 이슈의 경우 이슈 번호 앞에 `closed` 키워드를 붙여주세요.  
ex) `closed #2` -->
- closed #107 


## ✨ 작업 내용
<!-- 핵심적으로 변경된 사항들을 간략하게 서술해주세요. -> 예시: S3 업로드 기능 추가 -->
- 인게임 퇴장 기능을 구현했습니다 !
- 자세한 스펙과 관련 내용은 노션에 작성해 두었습니다


## 🎯 리뷰 포인트
<!-- 리뷰시 중점적으로 봐주었으면 좋을 부분을 적어주세요.  
없다면 적지 않아도 됩니다. -->  

## 📝 기타
<!-- 위 항목 외에 공유하고 싶은 내용이 있다면 작성해주세요. 없다면 적지 않아도 됩니다.
-> 예: 작업 중 고민했던 점, 임시로 처리한 부분, 후속 작업 예정 등 -->


[퇴장 흐름]

```
DELETE /api/games/{gameId}/leave
  │
  ├─ 게임 상태 == WAITING (로비)
  │    │
  │    ├─ 마지막 참가자
  │    │    → 게임 방 삭제 (이벤트 없음)
  │    │
  │    ├─ 방장 퇴장
  │    │    → [lobby] EXIT
  │    │    → [lobby] HOST_CHANGED
  │    │
  │    └─ 일반 퇴장
  │         → [lobby] EXIT
  │
  └─ 게임 상태 == IN_PROGRESS (인게임)
       │
       ├─ team == POLICE (POLICE_WAITING / ALIVE)
       │    ├─ 경찰 남아있음  → [system] PLAYER_LEFT
       │    └─ 마지막 경찰   → [system] GAME_OVER (POLICE_FORFEITED, winnerTeam=ROBBER)
       │
       ├─ team == ROBBER & status == ALIVE
       │    ├─ 생존 도둑 남아있음  → [system] PLAYER_LEFT
       │    └─ 마지막 생존 도둑   → [system] GAME_OVER (ROBBER_FORFEITED, winnerTeam=POLICE)
       │
       └─ team == ROBBER & status == JAILED
            → [system] PLAYER_LEFT

* 방장 퇴장 시 위 케이스와 무관하게 [lobby] HOST_CHANGED 추가 발행
```



- 후속 작업으로 이벤트 게임방 관련 구현을 하겠습니다.


## ✅ 테스트
- [ ] 수동 테스트 완료
- [x] 테스트 코드 완료
