### PR TITLE
feat: 어드민 GraphQL API(유저+게임결과) 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     // Spring Boot Starters
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-graphql'
+    implementation 'com.graphql-java:graphql-java-extended-scalars:22.0'
     implementation('org.redisson:redisson-spring-boot-starter:3.45.0') {
         exclude group: 'io.lettuce', module: 'lettuce-core'
     }

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ repositories {
 dependencies {
     // Spring Boot Starters
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-graphql'
     implementation('org.redisson:redisson-spring-boot-starter:3.45.0') {
         exclude group: 'io.lettuce', module: 'lettuce-core'
     }

--- a/src/main/java/com/team/cops_and_robbers/admin/application/AdminGameService.java
+++ b/src/main/java/com/team/cops_and_robbers/admin/application/AdminGameService.java
@@ -1,0 +1,102 @@
+package com.team.cops_and_robbers.admin.application;
+
+import com.team.cops_and_robbers.admin.application.dto.command.AdminGameListCommand;
+import com.team.cops_and_robbers.admin.application.dto.result.AdminGameAreaResult;
+import com.team.cops_and_robbers.admin.application.dto.result.AdminGamePageResult;
+import com.team.cops_and_robbers.admin.application.dto.result.AdminGameResult;
+import com.team.cops_and_robbers.admin.application.dto.result.AdminGameResultDetail;
+import com.team.cops_and_robbers.admin.application.dto.result.AdminGameSummaryResult;
+import com.team.cops_and_robbers.admin.application.dto.result.AdminParticipantResult;
+import com.team.cops_and_robbers.game.area.repository.GameAreaRepository;
+import com.team.cops_and_robbers.game.game.domain.Game;
+import com.team.cops_and_robbers.game.game.repository.GameRepository;
+import com.team.cops_and_robbers.game.participant.repository.GameParticipantCountProjection;
+import com.team.cops_and_robbers.game.participant.repository.GameParticipantRepository;
+import com.team.cops_and_robbers.history.domain.GameResult;
+import com.team.cops_and_robbers.history.repository.GameResultRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminGameService {
+
+    private final GameRepository gameRepository;
+    private final GameParticipantRepository gameParticipantRepository;
+    private final GameAreaRepository gameAreaRepository;
+    private final GameResultRepository gameResultRepository;
+
+    public AdminGamePageResult getGameList(AdminGameListCommand command) {
+        Page<Game> gamePage = gameRepository.findAllForAdmin(command.status(), command.toPageable());
+        List<Long> gameIds = gamePage.getContent().stream().map(Game::getId).toList();
+        Map<Long, Integer> countByGameId = gameParticipantRepository.countByGameIdIn(gameIds)
+                .stream()
+                .collect(Collectors.toMap(
+                        GameParticipantCountProjection::gameId,
+                        p -> p.count().intValue()
+                ));
+        Page<AdminGameSummaryResult> summaryPage = gamePage.map(game ->
+                AdminGameSummaryResult.from(game, countByGameId.getOrDefault(game.getId(), 0)));
+        return AdminGamePageResult.from(summaryPage);
+    }
+
+    public AdminGameResult getGame(Long gameId) {
+        Game game = gameRepository.getByGameId(gameId);
+        return AdminGameResult.from(game);
+    }
+
+    public Map<AdminGameResult, List<AdminParticipantResult>> getParticipantsByGame(
+            List<AdminGameResult> games) {
+        List<Long> gameIds = games.stream().map(AdminGameResult::id).toList();
+        Map<Long, List<AdminParticipantResult>> participantsByGameId =
+                gameParticipantRepository.findByGameIdInWithUser(gameIds)
+                        .stream()
+                        .collect(Collectors.groupingBy(
+                                gp -> gp.getGame().getId(),
+                                Collectors.mapping(AdminParticipantResult::from, Collectors.toList())
+                        ));
+        return games.stream().collect(Collectors.toMap(
+                game -> game,
+                game -> participantsByGameId.getOrDefault(game.id(), List.of())
+        ));
+    }
+
+    public Map<AdminGameResult, AdminGameResultDetail> getResultsByGame(List<AdminGameResult> games) {
+        List<Long> gameIds = games.stream().map(AdminGameResult::id).toList();
+        Map<Long, AdminGameResultDetail> resultByGameId = gameResultRepository.findByGameIdIn(gameIds)
+                .stream()
+                .collect(Collectors.toMap(
+                        GameResult::getGameId,
+                        AdminGameResultDetail::from
+                ));
+        return games.stream()
+                .filter(game -> resultByGameId.containsKey(game.id()))
+                .collect(Collectors.toMap(
+                        game -> game,
+                        game -> resultByGameId.get(game.id())
+                ));
+    }
+
+    public Map<AdminGameResult, AdminGameAreaResult> getAreasByGame(List<AdminGameResult> games) {
+        List<Long> gameIds = games.stream().map(AdminGameResult::id).toList();
+        Map<Long, AdminGameAreaResult> areaByGameId = gameAreaRepository.findByGameIdIn(gameIds)
+                .stream()
+                .collect(Collectors.toMap(
+                        ga -> ga.getGame().getId(),
+                        AdminGameAreaResult::from
+                ));
+        return games.stream()
+                .filter(game -> areaByGameId.containsKey(game.id()))
+                .collect(Collectors.toMap(
+                        game -> game,
+                        game -> areaByGameId.get(game.id())
+                ));
+    }
+}

--- a/src/main/java/com/team/cops_and_robbers/admin/application/AdminGameService.java
+++ b/src/main/java/com/team/cops_and_robbers/admin/application/AdminGameService.java
@@ -4,7 +4,7 @@ import com.team.cops_and_robbers.admin.application.dto.command.AdminGameListComm
 import com.team.cops_and_robbers.admin.application.dto.result.AdminGameAreaResult;
 import com.team.cops_and_robbers.admin.application.dto.result.AdminGamePageResult;
 import com.team.cops_and_robbers.admin.application.dto.result.AdminGameResult;
-import com.team.cops_and_robbers.admin.application.dto.result.AdminGameResultDetail;
+import com.team.cops_and_robbers.admin.application.dto.result.AdminGameDetailResult;
 import com.team.cops_and_robbers.admin.application.dto.result.AdminGameSummaryResult;
 import com.team.cops_and_robbers.admin.application.dto.result.AdminParticipantResult;
 import com.team.cops_and_robbers.game.area.repository.GameAreaRepository;
@@ -68,13 +68,13 @@ public class AdminGameService {
         ));
     }
 
-    public Map<AdminGameResult, AdminGameResultDetail> getResultsByGame(List<AdminGameResult> games) {
+    public Map<AdminGameResult, AdminGameDetailResult> getResultsByGame(List<AdminGameResult> games) {
         List<Long> gameIds = games.stream().map(AdminGameResult::id).toList();
-        Map<Long, AdminGameResultDetail> resultByGameId = gameResultRepository.findByGameIdIn(gameIds)
+        Map<Long, AdminGameDetailResult> resultByGameId = gameResultRepository.findByGameIdIn(gameIds)
                 .stream()
                 .collect(Collectors.toMap(
                         GameResult::getGameId,
-                        AdminGameResultDetail::from
+                        AdminGameDetailResult::from
                 ));
         return games.stream()
                 .filter(game -> resultByGameId.containsKey(game.id()))

--- a/src/main/java/com/team/cops_and_robbers/admin/application/AdminUserService.java
+++ b/src/main/java/com/team/cops_and_robbers/admin/application/AdminUserService.java
@@ -1,0 +1,74 @@
+package com.team.cops_and_robbers.admin.application;
+
+import com.team.cops_and_robbers.admin.application.dto.command.AdminUserListCommand;
+import com.team.cops_and_robbers.admin.application.dto.result.AdminUserPageResult;
+import com.team.cops_and_robbers.admin.application.dto.result.AdminUserResult;
+import com.team.cops_and_robbers.admin.application.dto.result.GameParticipationResult;
+import com.team.cops_and_robbers.admin.application.dto.result.UserDeviceResult;
+import com.team.cops_and_robbers.game.participant.repository.GameParticipantRepository;
+import com.team.cops_and_robbers.user.domain.User;
+import com.team.cops_and_robbers.user.repository.UserDeviceRepository;
+import com.team.cops_and_robbers.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminUserService {
+
+    private final UserRepository userRepository;
+    private final UserDeviceRepository userDeviceRepository;
+    private final GameParticipantRepository gameParticipantRepository;
+
+    public AdminUserPageResult getUserList(AdminUserListCommand command) {
+        Page<User> userPage = userRepository.findAllForAdmin(
+                command.nickname(), command.socialType(), command.fromDate(), command.toDate(),
+                command.toPageable());
+        return AdminUserPageResult.from(userPage);
+    }
+
+    public AdminUserResult getUser(Long userId) {
+        User user = userRepository.getByUserId(userId);
+        return AdminUserResult.from(user);
+    }
+
+    public Map<AdminUserResult, UserDeviceResult> getDevicesByUsers(List<AdminUserResult> users) {
+        List<Long> userIds = users.stream().map(AdminUserResult::id).toList();
+        Map<Long, UserDeviceResult> deviceByUserId = userDeviceRepository.findByUser_IdIn(userIds)
+                .stream()
+                .collect(Collectors.toMap(
+                        ud -> ud.getUser().getId(),
+                        UserDeviceResult::from
+                ));
+        return users.stream()
+                .filter(user -> deviceByUserId.containsKey(user.id()))
+                .collect(Collectors.toMap(
+                        user -> user,
+                        user -> deviceByUserId.get(user.id())
+                ));
+    }
+
+    public Map<AdminUserResult, List<GameParticipationResult>> getGameParticipationsByUsers(
+            List<AdminUserResult> users) {
+        List<Long> userIds = users.stream().map(AdminUserResult::id).toList();
+        Map<Long, List<GameParticipationResult>> participationsByUserId =
+                gameParticipantRepository.findByUserIdInWithGame(userIds)
+                        .stream()
+                        .collect(Collectors.groupingBy(
+                                gp -> gp.getUser().getId(),
+                                Collectors.mapping(GameParticipationResult::from, Collectors.toList())
+                        ));
+
+        return users.stream().collect(Collectors.toMap(
+                user -> user,
+                user -> participationsByUserId.getOrDefault(user.id(), List.of())
+        ));
+    }
+}

--- a/src/main/java/com/team/cops_and_robbers/admin/application/dto/SortDirection.java
+++ b/src/main/java/com/team/cops_and_robbers/admin/application/dto/SortDirection.java
@@ -1,0 +1,11 @@
+package com.team.cops_and_robbers.admin.application.dto;
+
+import org.springframework.data.domain.Sort;
+
+public enum SortDirection {
+    ASC, DESC;
+
+    public Sort.Direction toSpringDirection() {
+        return this == ASC ? Sort.Direction.ASC : Sort.Direction.DESC;
+    }
+}

--- a/src/main/java/com/team/cops_and_robbers/admin/application/dto/command/AdminGameListCommand.java
+++ b/src/main/java/com/team/cops_and_robbers/admin/application/dto/command/AdminGameListCommand.java
@@ -1,0 +1,19 @@
+package com.team.cops_and_robbers.admin.application.dto.command;
+
+import com.team.cops_and_robbers.admin.application.dto.SortDirection;
+import com.team.cops_and_robbers.game.game.domain.GameStatus;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+public record AdminGameListCommand(
+        int page,
+        int size,
+        GameStatus status,
+        SortDirection sortDirection
+) {
+
+    public Pageable toPageable() {
+        return PageRequest.of(page, size, Sort.by(sortDirection.toSpringDirection(), "createdAt"));
+    }
+}

--- a/src/main/java/com/team/cops_and_robbers/admin/application/dto/command/AdminUserListCommand.java
+++ b/src/main/java/com/team/cops_and_robbers/admin/application/dto/command/AdminUserListCommand.java
@@ -1,0 +1,24 @@
+package com.team.cops_and_robbers.admin.application.dto.command;
+
+import com.team.cops_and_robbers.admin.application.dto.SortDirection;
+import com.team.cops_and_robbers.user.domain.SocialType;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+import java.time.LocalDateTime;
+
+public record AdminUserListCommand(
+        int page,
+        int size,
+        String nickname,
+        SocialType socialType,
+        LocalDateTime fromDate,
+        LocalDateTime toDate,
+        SortDirection sortDirection
+) {
+
+    public Pageable toPageable() {
+        return PageRequest.of(page, size, Sort.by(sortDirection.toSpringDirection(), "createdAt"));
+    }
+}

--- a/src/main/java/com/team/cops_and_robbers/admin/application/dto/result/AdminGameAreaResult.java
+++ b/src/main/java/com/team/cops_and_robbers/admin/application/dto/result/AdminGameAreaResult.java
@@ -1,0 +1,23 @@
+package com.team.cops_and_robbers.admin.application.dto.result;
+
+import com.team.cops_and_robbers.game.area.domain.GameArea;
+
+public record AdminGameAreaResult(
+        Double playgroundCenterLat,
+        Double playgroundCenterLng,
+        Integer playgroundRadiusInMeters,
+        Double jailCenterLat,
+        Double jailCenterLng,
+        Integer jailRadiusInMeters
+) {
+    public static AdminGameAreaResult from(GameArea gameArea) {
+        return new AdminGameAreaResult(
+                gameArea.getPlaygroundCenter().getY(),
+                gameArea.getPlaygroundCenter().getX(),
+                gameArea.getPlaygroundRadiusInMeters(),
+                gameArea.getJailCenter().getY(),
+                gameArea.getJailCenter().getX(),
+                gameArea.getJailRadiusInMeters()
+        );
+    }
+}

--- a/src/main/java/com/team/cops_and_robbers/admin/application/dto/result/AdminGameAreaResult.java
+++ b/src/main/java/com/team/cops_and_robbers/admin/application/dto/result/AdminGameAreaResult.java
@@ -1,23 +1,58 @@
 package com.team.cops_and_robbers.admin.application.dto.result;
 
+import com.team.cops_and_robbers.game.area.domain.AreaType;
 import com.team.cops_and_robbers.game.area.domain.GameArea;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Polygon;
+
+import java.util.Arrays;
+import java.util.List;
 
 public record AdminGameAreaResult(
+        AreaType areaType,
         Double playgroundCenterLat,
         Double playgroundCenterLng,
         Integer playgroundRadiusInMeters,
         Double jailCenterLat,
         Double jailCenterLng,
-        Integer jailRadiusInMeters
+        Integer jailRadiusInMeters,
+        List<AdminCoordinateResult> playgroundPolygon,
+        List<AdminCoordinateResult> jailPolygon
 ) {
+
+    public record AdminCoordinateResult(Double latitude, Double longitude) {}
+
     public static AdminGameAreaResult from(GameArea gameArea) {
-        return new AdminGameAreaResult(
-                gameArea.getPlaygroundCenter().getY(),
-                gameArea.getPlaygroundCenter().getX(),
-                gameArea.getPlaygroundRadiusInMeters(),
-                gameArea.getJailCenter().getY(),
-                gameArea.getJailCenter().getX(),
-                gameArea.getJailRadiusInMeters()
-        );
+        return switch (gameArea.getAreaType()) {
+            case CIRCLE -> new AdminGameAreaResult(
+                    AreaType.CIRCLE,
+                    gameArea.getPlaygroundCenter().getY(),
+                    gameArea.getPlaygroundCenter().getX(),
+                    gameArea.getPlaygroundRadiusInMeters(),
+                    gameArea.getJailCenter().getY(),
+                    gameArea.getJailCenter().getX(),
+                    gameArea.getJailRadiusInMeters(),
+                    null,
+                    null
+            );
+            case POLYGON -> new AdminGameAreaResult(
+                    AreaType.POLYGON,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    toCoordinatesList(gameArea.getPlaygroundPolygon()),
+                    toCoordinatesList(gameArea.getJailPolygon())
+            );
+        };
+    }
+
+    private static List<AdminCoordinateResult> toCoordinatesList(Polygon polygon) {
+        Coordinate[] coordinates = polygon.getCoordinates();
+        return Arrays.stream(coordinates, 0, coordinates.length - 1)
+                .map(c -> new AdminCoordinateResult(c.y, c.x))
+                .toList();
     }
 }

--- a/src/main/java/com/team/cops_and_robbers/admin/application/dto/result/AdminGameDetailResult.java
+++ b/src/main/java/com/team/cops_and_robbers/admin/application/dto/result/AdminGameDetailResult.java
@@ -4,7 +4,7 @@ import com.team.cops_and_robbers.game.participant.domain.Team;
 import com.team.cops_and_robbers.history.domain.GameEndReason;
 import com.team.cops_and_robbers.history.domain.GameResult;
 
-public record AdminGameResultDetail(
+public record AdminGameDetailResult(
         Team winnerTeam,
         GameEndReason endReason,
         Integer totalPoliceCount,
@@ -15,8 +15,8 @@ public record AdminGameResultDetail(
         Double playgroundCenterLng,
         Integer playgroundRadiusInMeters
 ) {
-    public static AdminGameResultDetail from(GameResult gameResult) {
-        return new AdminGameResultDetail(
+    public static AdminGameDetailResult from(GameResult gameResult) {
+        return new AdminGameDetailResult(
                 gameResult.getWinnerTeam(),
                 gameResult.getEndReason(),
                 gameResult.getTotalPoliceCount(),

--- a/src/main/java/com/team/cops_and_robbers/admin/application/dto/result/AdminGameDetailResult.java
+++ b/src/main/java/com/team/cops_and_robbers/admin/application/dto/result/AdminGameDetailResult.java
@@ -10,10 +10,7 @@ public record AdminGameDetailResult(
         Integer totalPoliceCount,
         Integer totalRobberCount,
         Integer arrestedRobberCount,
-        Integer durationSeconds,
-        Double playgroundCenterLat,
-        Double playgroundCenterLng,
-        Integer playgroundRadiusInMeters
+        Integer durationSeconds
 ) {
     public static AdminGameDetailResult from(GameResult gameResult) {
         return new AdminGameDetailResult(
@@ -22,10 +19,7 @@ public record AdminGameDetailResult(
                 gameResult.getTotalPoliceCount(),
                 gameResult.getTotalRobberCount(),
                 gameResult.getArrestedRobberCount(),
-                gameResult.getDurationSeconds(),
-                gameResult.getPlaygroundCenter().getY(),
-                gameResult.getPlaygroundCenter().getX(),
-                gameResult.getPlaygroundRadiusInMeters()
+                gameResult.getDurationSeconds()
         );
     }
 }

--- a/src/main/java/com/team/cops_and_robbers/admin/application/dto/result/AdminGamePageResult.java
+++ b/src/main/java/com/team/cops_and_robbers/admin/application/dto/result/AdminGamePageResult.java
@@ -1,0 +1,23 @@
+package com.team.cops_and_robbers.admin.application.dto.result;
+
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+public record AdminGamePageResult(
+        List<AdminGameSummaryResult> content,
+        Long totalElements,
+        Integer totalPages,
+        Integer page,
+        Integer size
+) {
+    public static AdminGamePageResult from(Page<AdminGameSummaryResult> summaryPage) {
+        return new AdminGamePageResult(
+                summaryPage.getContent(),
+                summaryPage.getTotalElements(),
+                summaryPage.getTotalPages(),
+                summaryPage.getNumber(),
+                summaryPage.getSize()
+        );
+    }
+}

--- a/src/main/java/com/team/cops_and_robbers/admin/application/dto/result/AdminGameResult.java
+++ b/src/main/java/com/team/cops_and_robbers/admin/application/dto/result/AdminGameResult.java
@@ -1,0 +1,36 @@
+package com.team.cops_and_robbers.admin.application.dto.result;
+
+import com.team.cops_and_robbers.common.util.TimestampUtil;
+import com.team.cops_and_robbers.game.game.domain.Game;
+import com.team.cops_and_robbers.game.game.domain.GameStatus;
+
+public record AdminGameResult(
+        Long id,
+        String inviteCode,
+        GameStatus status,
+        Integer roundDurationMinutes,
+        Integer locationRevealIntervalMinutes,
+        Integer policeWaitMinutes,
+        Integer maxParticipants,
+        Boolean isEventGame,
+        String createdAt,
+        String startedAt
+) {
+    public static AdminGameResult from(Game game) {
+        String startedAt = game.getStartedAt() != null
+                ? TimestampUtil.toIsoString(game.getStartedAt())
+                : null;
+        return new AdminGameResult(
+                game.getId(),
+                game.getInviteCode(),
+                game.getStatus(),
+                game.getRoundDurationMinutes(),
+                game.getLocationRevealIntervalMinutes(),
+                game.getPoliceWaitMinutes(),
+                game.getMaxParticipants(),
+                game.isEventGame(),
+                TimestampUtil.toIsoString(game.getCreatedAt()),
+                startedAt
+        );
+    }
+}

--- a/src/main/java/com/team/cops_and_robbers/admin/application/dto/result/AdminGameResultDetail.java
+++ b/src/main/java/com/team/cops_and_robbers/admin/application/dto/result/AdminGameResultDetail.java
@@ -1,0 +1,31 @@
+package com.team.cops_and_robbers.admin.application.dto.result;
+
+import com.team.cops_and_robbers.game.participant.domain.Team;
+import com.team.cops_and_robbers.history.domain.GameEndReason;
+import com.team.cops_and_robbers.history.domain.GameResult;
+
+public record AdminGameResultDetail(
+        Team winnerTeam,
+        GameEndReason endReason,
+        Integer totalPoliceCount,
+        Integer totalRobberCount,
+        Integer arrestedRobberCount,
+        Integer durationSeconds,
+        Double playgroundCenterLat,
+        Double playgroundCenterLng,
+        Integer playgroundRadiusInMeters
+) {
+    public static AdminGameResultDetail from(GameResult gameResult) {
+        return new AdminGameResultDetail(
+                gameResult.getWinnerTeam(),
+                gameResult.getEndReason(),
+                gameResult.getTotalPoliceCount(),
+                gameResult.getTotalRobberCount(),
+                gameResult.getArrestedRobberCount(),
+                gameResult.getDurationSeconds(),
+                gameResult.getPlaygroundCenter().getY(),
+                gameResult.getPlaygroundCenter().getX(),
+                gameResult.getPlaygroundRadiusInMeters()
+        );
+    }
+}

--- a/src/main/java/com/team/cops_and_robbers/admin/application/dto/result/AdminGameSummaryResult.java
+++ b/src/main/java/com/team/cops_and_robbers/admin/application/dto/result/AdminGameSummaryResult.java
@@ -1,0 +1,31 @@
+package com.team.cops_and_robbers.admin.application.dto.result;
+
+import com.team.cops_and_robbers.common.util.TimestampUtil;
+import com.team.cops_and_robbers.game.game.domain.Game;
+import com.team.cops_and_robbers.game.game.domain.GameStatus;
+
+public record AdminGameSummaryResult(
+        Long id,
+        String inviteCode,
+        GameStatus status,
+        Integer roundDurationMinutes,
+        Integer locationRevealIntervalMinutes,
+        Integer maxParticipants,
+        Boolean isEventGame,
+        Integer participantCount,
+        String createdAt
+) {
+    public static AdminGameSummaryResult from(Game game, int participantCount) {
+        return new AdminGameSummaryResult(
+                game.getId(),
+                game.getInviteCode(),
+                game.getStatus(),
+                game.getRoundDurationMinutes(),
+                game.getLocationRevealIntervalMinutes(),
+                game.getMaxParticipants(),
+                game.isEventGame(),
+                participantCount,
+                TimestampUtil.toIsoString(game.getCreatedAt())
+        );
+    }
+}

--- a/src/main/java/com/team/cops_and_robbers/admin/application/dto/result/AdminParticipantResult.java
+++ b/src/main/java/com/team/cops_and_robbers/admin/application/dto/result/AdminParticipantResult.java
@@ -1,0 +1,23 @@
+package com.team.cops_and_robbers.admin.application.dto.result;
+
+import com.team.cops_and_robbers.game.participant.domain.GameParticipant;
+import com.team.cops_and_robbers.game.participant.domain.ParticipantStatus;
+import com.team.cops_and_robbers.game.participant.domain.Team;
+
+public record AdminParticipantResult(
+        Long userId,
+        String nickname,
+        Team team,
+        ParticipantStatus status,
+        Boolean isHost
+) {
+    public static AdminParticipantResult from(GameParticipant participant) {
+        return new AdminParticipantResult(
+                participant.getUser().getId(),
+                participant.getUser().getNickname(),
+                participant.getTeam(),
+                participant.getStatus(),
+                participant.isHost()
+        );
+    }
+}

--- a/src/main/java/com/team/cops_and_robbers/admin/application/dto/result/AdminUserPageResult.java
+++ b/src/main/java/com/team/cops_and_robbers/admin/application/dto/result/AdminUserPageResult.java
@@ -1,0 +1,27 @@
+package com.team.cops_and_robbers.admin.application.dto.result;
+
+import com.team.cops_and_robbers.user.domain.User;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+public record AdminUserPageResult(
+        List<AdminUserResult> content,
+        Long totalElements,
+        Integer totalPages,
+        Integer page,
+        Integer size
+) {
+    public static AdminUserPageResult from(Page<User> userPage) {
+        List<AdminUserResult> content = userPage.getContent().stream()
+                .map(AdminUserResult::from)
+                .toList();
+        return new AdminUserPageResult(
+                content,
+                userPage.getTotalElements(),
+                userPage.getTotalPages(),
+                userPage.getNumber(),
+                userPage.getSize()
+        );
+    }
+}

--- a/src/main/java/com/team/cops_and_robbers/admin/application/dto/result/AdminUserResult.java
+++ b/src/main/java/com/team/cops_and_robbers/admin/application/dto/result/AdminUserResult.java
@@ -1,0 +1,30 @@
+package com.team.cops_and_robbers.admin.application.dto.result;
+
+import com.team.cops_and_robbers.common.util.TimestampUtil;
+import com.team.cops_and_robbers.user.domain.Role;
+import com.team.cops_and_robbers.user.domain.SocialType;
+import com.team.cops_and_robbers.user.domain.User;
+
+public record AdminUserResult(
+        Long id,
+        String nickname,
+        SocialType socialType,
+        Role role,
+        Boolean termsOfServiceAgreed,
+        Boolean privacyPolicyAgreed,
+        Boolean locationTermsAgreed,
+        String createdAt
+) {
+    public static AdminUserResult from(User user) {
+        return new AdminUserResult(
+                user.getId(),
+                user.getNickname(),
+                user.getSocialType(),
+                user.getRole(),
+                user.isTermsOfServiceAgreed(),
+                user.isPrivacyPolicyAgreed(),
+                user.isLocationTermsAgreed(),
+                TimestampUtil.toIsoString(user.getCreatedAt())
+        );
+    }
+}

--- a/src/main/java/com/team/cops_and_robbers/admin/application/dto/result/GameParticipationResult.java
+++ b/src/main/java/com/team/cops_and_robbers/admin/application/dto/result/GameParticipationResult.java
@@ -1,0 +1,26 @@
+package com.team.cops_and_robbers.admin.application.dto.result;
+
+import com.team.cops_and_robbers.common.util.TimestampUtil;
+import com.team.cops_and_robbers.game.participant.domain.GameParticipant;
+import com.team.cops_and_robbers.game.participant.domain.ParticipantStatus;
+import com.team.cops_and_robbers.game.participant.domain.Team;
+
+public record GameParticipationResult(
+        Long gameId,
+        String inviteCode,
+        Team team,
+        ParticipantStatus status,
+        Boolean isHost,
+        String createdAt
+) {
+    public static GameParticipationResult from(GameParticipant participant) {
+        return new GameParticipationResult(
+                participant.getGame().getId(),
+                participant.getGame().getInviteCode(),
+                participant.getTeam(),
+                participant.getStatus(),
+                participant.isHost(),
+                TimestampUtil.toIsoString(participant.getCreatedAt())
+        );
+    }
+}

--- a/src/main/java/com/team/cops_and_robbers/admin/application/dto/result/UserDeviceResult.java
+++ b/src/main/java/com/team/cops_and_robbers/admin/application/dto/result/UserDeviceResult.java
@@ -1,0 +1,17 @@
+package com.team.cops_and_robbers.admin.application.dto.result;
+
+import com.team.cops_and_robbers.common.util.TimestampUtil;
+import com.team.cops_and_robbers.user.domain.DeviceType;
+import com.team.cops_and_robbers.user.domain.UserDevice;
+
+public record UserDeviceResult(
+        DeviceType deviceType,
+        String createdAt
+) {
+    public static UserDeviceResult from(UserDevice userDevice) {
+        return new UserDeviceResult(
+                userDevice.getDeviceType(),
+                TimestampUtil.toIsoString(userDevice.getCreatedAt())
+        );
+    }
+}

--- a/src/main/java/com/team/cops_and_robbers/admin/exception/AdminException.java
+++ b/src/main/java/com/team/cops_and_robbers/admin/exception/AdminException.java
@@ -1,0 +1,19 @@
+package com.team.cops_and_robbers.admin.exception;
+
+import com.team.cops_and_robbers.common.exception.ExceptionCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum AdminException implements ExceptionCode {
+
+    NOT_AUTHENTICATED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다.", "로그인 후 이용해주세요."),
+    FORBIDDEN_ADMIN_ONLY(HttpStatus.FORBIDDEN, "어드민 권한 필요", "어드민 계정만 접근할 수 있습니다."),
+    INVALID_DATE_FORMAT(HttpStatus.BAD_REQUEST, "잘못된 날짜 형식", "날짜 형식이 올바르지 않습니다. ISO 8601 형식으로 입력해주세요.");
+
+    private final HttpStatus httpStatus;
+    private final String title;
+    private final String detail;
+}

--- a/src/main/java/com/team/cops_and_robbers/admin/presentation/AdminGameResolver.java
+++ b/src/main/java/com/team/cops_and_robbers/admin/presentation/AdminGameResolver.java
@@ -1,0 +1,61 @@
+package com.team.cops_and_robbers.admin.presentation;
+
+import com.team.cops_and_robbers.admin.application.AdminGameService;
+import com.team.cops_and_robbers.admin.application.dto.command.AdminGameListCommand;
+import com.team.cops_and_robbers.admin.application.dto.result.AdminGameAreaResult;
+import com.team.cops_and_robbers.admin.application.dto.result.AdminGamePageResult;
+import com.team.cops_and_robbers.admin.application.dto.result.AdminGameResult;
+import com.team.cops_and_robbers.admin.application.dto.result.AdminGameResultDetail;
+import com.team.cops_and_robbers.admin.application.dto.result.AdminParticipantResult;
+import com.team.cops_and_robbers.admin.application.dto.SortDirection;
+import com.team.cops_and_robbers.game.game.domain.GameStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.graphql.data.method.annotation.Argument;
+import org.springframework.graphql.data.method.annotation.BatchMapping;
+import org.springframework.graphql.data.method.annotation.QueryMapping;
+import org.springframework.stereotype.Controller;
+
+import java.util.List;
+import java.util.Map;
+
+@Controller
+@RequiredArgsConstructor
+public class AdminGameResolver {
+
+    private final AdminGameService adminGameService;
+
+    @QueryMapping
+    public AdminGamePageResult adminGames(
+            @Argument int page,
+            @Argument int size,
+            @Argument GameStatus status,
+            @Argument SortDirection sortDirection
+    ) {
+        AdminGameListCommand command = new AdminGameListCommand(
+                page, size, status, sortDirection != null ? sortDirection : SortDirection.DESC);
+        return adminGameService.getGameList(command);
+    }
+
+    @QueryMapping
+    public AdminGameResult adminGame(@Argument Long id) {
+        return adminGameService.getGame(id);
+    }
+
+    @BatchMapping(typeName = "AdminGame", field = "participants")
+    public Map<AdminGameResult, List<AdminParticipantResult>> participants(
+            List<AdminGameResult> games) {
+        return adminGameService.getParticipantsByGame(games);
+    }
+
+    @BatchMapping(typeName = "AdminGame", field = "result")
+    public Map<AdminGameResult, AdminGameResultDetail> result(
+            List<AdminGameResult> games) {
+        return adminGameService.getResultsByGame(games);
+    }
+
+    @BatchMapping(typeName = "AdminGame", field = "area")
+    public Map<AdminGameResult, AdminGameAreaResult> area(
+            List<AdminGameResult> games) {
+        return adminGameService.getAreasByGame(games);
+    }
+}

--- a/src/main/java/com/team/cops_and_robbers/admin/presentation/AdminGameResolver.java
+++ b/src/main/java/com/team/cops_and_robbers/admin/presentation/AdminGameResolver.java
@@ -5,7 +5,7 @@ import com.team.cops_and_robbers.admin.application.dto.command.AdminGameListComm
 import com.team.cops_and_robbers.admin.application.dto.result.AdminGameAreaResult;
 import com.team.cops_and_robbers.admin.application.dto.result.AdminGamePageResult;
 import com.team.cops_and_robbers.admin.application.dto.result.AdminGameResult;
-import com.team.cops_and_robbers.admin.application.dto.result.AdminGameResultDetail;
+import com.team.cops_and_robbers.admin.application.dto.result.AdminGameDetailResult;
 import com.team.cops_and_robbers.admin.application.dto.result.AdminParticipantResult;
 import com.team.cops_and_robbers.admin.application.dto.SortDirection;
 import com.team.cops_and_robbers.game.game.domain.GameStatus;
@@ -48,7 +48,7 @@ public class AdminGameResolver {
     }
 
     @BatchMapping(typeName = "AdminGame", field = "result")
-    public Map<AdminGameResult, AdminGameResultDetail> result(
+    public Map<AdminGameResult, AdminGameDetailResult> result(
             List<AdminGameResult> games) {
         return adminGameService.getResultsByGame(games);
     }

--- a/src/main/java/com/team/cops_and_robbers/admin/presentation/AdminGameResolver.java
+++ b/src/main/java/com/team/cops_and_robbers/admin/presentation/AdminGameResolver.java
@@ -9,15 +9,19 @@ import com.team.cops_and_robbers.admin.application.dto.result.AdminGameDetailRes
 import com.team.cops_and_robbers.admin.application.dto.result.AdminParticipantResult;
 import com.team.cops_and_robbers.admin.application.dto.SortDirection;
 import com.team.cops_and_robbers.game.game.domain.GameStatus;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.graphql.data.method.annotation.Argument;
 import org.springframework.graphql.data.method.annotation.BatchMapping;
 import org.springframework.graphql.data.method.annotation.QueryMapping;
 import org.springframework.stereotype.Controller;
+import org.springframework.validation.annotation.Validated;
 
 import java.util.List;
 import java.util.Map;
 
+@Validated
 @Controller
 @RequiredArgsConstructor
 public class AdminGameResolver {
@@ -26,8 +30,8 @@ public class AdminGameResolver {
 
     @QueryMapping
     public AdminGamePageResult adminGames(
-            @Argument int page,
-            @Argument int size,
+            @Argument @Min(0) int page,
+            @Argument @Min(1) @Max(100) int size,
             @Argument GameStatus status,
             @Argument SortDirection sortDirection
     ) {

--- a/src/main/java/com/team/cops_and_robbers/admin/presentation/AdminUserResolver.java
+++ b/src/main/java/com/team/cops_and_robbers/admin/presentation/AdminUserResolver.java
@@ -1,0 +1,75 @@
+package com.team.cops_and_robbers.admin.presentation;
+
+import com.team.cops_and_robbers.admin.application.AdminUserService;
+import com.team.cops_and_robbers.admin.application.dto.SortDirection;
+import com.team.cops_and_robbers.admin.application.dto.command.AdminUserListCommand;
+import com.team.cops_and_robbers.admin.exception.AdminException;
+import com.team.cops_and_robbers.common.exception.ApplicationException;
+import com.team.cops_and_robbers.admin.application.dto.result.AdminUserPageResult;
+import com.team.cops_and_robbers.admin.application.dto.result.AdminUserResult;
+import com.team.cops_and_robbers.admin.application.dto.result.GameParticipationResult;
+import com.team.cops_and_robbers.admin.application.dto.result.UserDeviceResult;
+import com.team.cops_and_robbers.common.util.TimestampUtil;
+import com.team.cops_and_robbers.user.domain.SocialType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.graphql.data.method.annotation.Argument;
+import org.springframework.graphql.data.method.annotation.BatchMapping;
+import org.springframework.graphql.data.method.annotation.QueryMapping;
+import org.springframework.stereotype.Controller;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeParseException;
+import java.util.List;
+import java.util.Map;
+
+@Controller
+@RequiredArgsConstructor
+public class AdminUserResolver {
+
+    private final AdminUserService adminUserService;
+
+    @QueryMapping
+    public AdminUserPageResult adminUsers(
+            @Argument int page,
+            @Argument int size,
+            @Argument String nickname,
+            @Argument SocialType socialType,
+            @Argument String fromDate,
+            @Argument String toDate,
+            @Argument SortDirection sortDirection
+    ) {
+        LocalDateTime parsedFromDate = parseDate(fromDate);
+        LocalDateTime parsedToDate = parseDate(toDate);
+        AdminUserListCommand command = new AdminUserListCommand(
+                page, size, nickname, socialType, parsedFromDate, parsedToDate,
+                sortDirection != null ? sortDirection : SortDirection.DESC);
+        return adminUserService.getUserList(command);
+    }
+
+    @QueryMapping
+    public AdminUserResult adminUser(@Argument Long id) {
+        return adminUserService.getUser(id);
+    }
+
+    @BatchMapping(typeName = "AdminUser", field = "device")
+    public Map<AdminUserResult, UserDeviceResult> device(List<AdminUserResult> users) {
+        return adminUserService.getDevicesByUsers(users);
+    }
+
+    @BatchMapping(typeName = "AdminUser", field = "participations")
+    public Map<AdminUserResult, List<GameParticipationResult>> participations(
+            List<AdminUserResult> users) {
+        return adminUserService.getGameParticipationsByUsers(users);
+    }
+
+    private LocalDateTime parseDate(String dateString) {
+        if (dateString == null) {
+            return null;
+        }
+        try {
+            return TimestampUtil.parseToKstLocalDateTime(dateString);
+        } catch (DateTimeParseException e) {
+            throw new ApplicationException(AdminException.INVALID_DATE_FORMAT);
+        }
+    }
+}

--- a/src/main/java/com/team/cops_and_robbers/admin/presentation/AdminUserResolver.java
+++ b/src/main/java/com/team/cops_and_robbers/admin/presentation/AdminUserResolver.java
@@ -3,25 +3,26 @@ package com.team.cops_and_robbers.admin.presentation;
 import com.team.cops_and_robbers.admin.application.AdminUserService;
 import com.team.cops_and_robbers.admin.application.dto.SortDirection;
 import com.team.cops_and_robbers.admin.application.dto.command.AdminUserListCommand;
-import com.team.cops_and_robbers.admin.exception.AdminException;
-import com.team.cops_and_robbers.common.exception.ApplicationException;
 import com.team.cops_and_robbers.admin.application.dto.result.AdminUserPageResult;
 import com.team.cops_and_robbers.admin.application.dto.result.AdminUserResult;
 import com.team.cops_and_robbers.admin.application.dto.result.GameParticipationResult;
 import com.team.cops_and_robbers.admin.application.dto.result.UserDeviceResult;
 import com.team.cops_and_robbers.common.util.TimestampUtil;
 import com.team.cops_and_robbers.user.domain.SocialType;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.graphql.data.method.annotation.Argument;
 import org.springframework.graphql.data.method.annotation.BatchMapping;
 import org.springframework.graphql.data.method.annotation.QueryMapping;
 import org.springframework.stereotype.Controller;
+import org.springframework.validation.annotation.Validated;
 
-import java.time.LocalDateTime;
-import java.time.format.DateTimeParseException;
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
 
+@Validated
 @Controller
 @RequiredArgsConstructor
 public class AdminUserResolver {
@@ -30,18 +31,18 @@ public class AdminUserResolver {
 
     @QueryMapping
     public AdminUserPageResult adminUsers(
-            @Argument int page,
-            @Argument int size,
+            @Argument @Min(0) int page,
+            @Argument @Min(1) @Max(100) int size,
             @Argument String nickname,
             @Argument SocialType socialType,
-            @Argument String fromDate,
-            @Argument String toDate,
+            @Argument OffsetDateTime fromDate,
+            @Argument OffsetDateTime toDate,
             @Argument SortDirection sortDirection
     ) {
-        LocalDateTime parsedFromDate = parseDate(fromDate);
-        LocalDateTime parsedToDate = parseDate(toDate);
         AdminUserListCommand command = new AdminUserListCommand(
-                page, size, nickname, socialType, parsedFromDate, parsedToDate,
+                page, size, nickname, socialType,
+                TimestampUtil.toKstLocalDateTime(fromDate),
+                TimestampUtil.toKstLocalDateTime(toDate),
                 sortDirection != null ? sortDirection : SortDirection.DESC);
         return adminUserService.getUserList(command);
     }
@@ -60,16 +61,5 @@ public class AdminUserResolver {
     public Map<AdminUserResult, List<GameParticipationResult>> participations(
             List<AdminUserResult> users) {
         return adminUserService.getGameParticipationsByUsers(users);
-    }
-
-    private LocalDateTime parseDate(String dateString) {
-        if (dateString == null) {
-            return null;
-        }
-        try {
-            return TimestampUtil.parseToKstLocalDateTime(dateString);
-        } catch (DateTimeParseException e) {
-            throw new ApplicationException(AdminException.INVALID_DATE_FORMAT);
-        }
     }
 }

--- a/src/main/java/com/team/cops_and_robbers/admin/presentation/interceptor/AdminInterceptor.java
+++ b/src/main/java/com/team/cops_and_robbers/admin/presentation/interceptor/AdminInterceptor.java
@@ -1,0 +1,33 @@
+package com.team.cops_and_robbers.admin.presentation.interceptor;
+
+import com.team.cops_and_robbers.admin.exception.AdminException;
+import com.team.cops_and_robbers.auth.infrastructure.jwt.JwtTokenProvider;
+import com.team.cops_and_robbers.common.exception.ApplicationException;
+import com.team.cops_and_robbers.common.util.AuthorizationExtractor;
+import com.team.cops_and_robbers.user.domain.Role;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Component
+@RequiredArgsConstructor
+public class AdminInterceptor implements HandlerInterceptor {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+        String accessToken = AuthorizationExtractor.extractToken(request)
+                .orElseThrow(() -> new ApplicationException(AdminException.NOT_AUTHENTICATED));
+
+        String role = jwtTokenProvider.getRoleFromAccessToken(accessToken);
+
+        if (!Role.ADMIN.name().equals(role)) {
+            throw new ApplicationException(AdminException.FORBIDDEN_ADMIN_ONLY);
+        }
+
+        return true;
+    }
+}

--- a/src/main/java/com/team/cops_and_robbers/admin/presentation/interceptor/AdminInterceptor.java
+++ b/src/main/java/com/team/cops_and_robbers/admin/presentation/interceptor/AdminInterceptor.java
@@ -2,6 +2,7 @@ package com.team.cops_and_robbers.admin.presentation.interceptor;
 
 import com.team.cops_and_robbers.admin.exception.AdminException;
 import com.team.cops_and_robbers.auth.infrastructure.jwt.JwtTokenProvider;
+import com.team.cops_and_robbers.auth.presentation.resolver.LoginUser;
 import com.team.cops_and_robbers.common.exception.ApplicationException;
 import com.team.cops_and_robbers.common.util.AuthorizationExtractor;
 import com.team.cops_and_robbers.user.domain.Role;
@@ -27,6 +28,9 @@ public class AdminInterceptor implements HandlerInterceptor {
         if (!Role.ADMIN.name().equals(role)) {
             throw new ApplicationException(AdminException.FORBIDDEN_ADMIN_ONLY);
         }
+
+        Long userId = jwtTokenProvider.getUserIdFromAccessToken(accessToken);
+        request.setAttribute("loginUser", new LoginUser(userId));
 
         return true;
     }

--- a/src/main/java/com/team/cops_and_robbers/auth/application/AuthService.java
+++ b/src/main/java/com/team/cops_and_robbers/auth/application/AuthService.java
@@ -1,7 +1,9 @@
 package com.team.cops_and_robbers.auth.application;
 
 
+import com.team.cops_and_robbers.auth.application.dto.command.AdminLoginCommand;
 import com.team.cops_and_robbers.auth.application.dto.command.LoginCommand;
+import com.team.cops_and_robbers.auth.application.dto.result.AdminLoginResult;
 import com.team.cops_and_robbers.auth.application.dto.result.LoginResult;
 import com.team.cops_and_robbers.auth.application.event.UserFcmTokenUpdatedEvent;
 import com.team.cops_and_robbers.auth.domain.Tokens;
@@ -159,6 +161,32 @@ public class AuthService {
                     refreshTokenRepository.delete(userId);
                     userDeviceRepository.deleteByUserId(userId);
                 });
+    }
+
+    /**
+     * 5. 어드민 웹 로그인
+     * - device sync 없이 토큰만 발급
+     * - ADMIN 권한이 아닌 유저 또는 미가입 유저는 403
+     */
+    @Transactional(readOnly = true)
+    public AdminLoginResult adminLogin(AdminLoginCommand command) {
+        String socialId = getSocialId(command.socialType(), command.idToken());
+
+        User user = userRepository.findBySocialIdAndSocialType(socialId, command.socialType())
+                .filter(User::isAdmin)
+                .orElseThrow(() -> new ApplicationException(AuthException.FORBIDDEN_ADMIN_ONLY));
+
+        Tokens tokens = issueTokens(user);
+        return AdminLoginResult.of(user, tokens);
+    }
+
+    /**
+     * 6. 어드민 웹 로그아웃
+     * - refreshToken만 삭제 (device 레코드는 유지하여 앱 푸시에 영향 없음)
+     */
+    public void adminLogout(String refreshToken) {
+        jwtTokenProvider.getUserIdFromRefreshTokenLogout(refreshToken)
+                .ifPresent(refreshTokenRepository::delete);
     }
 
     private record AuthUserData(

--- a/src/main/java/com/team/cops_and_robbers/auth/application/dto/command/AdminLoginCommand.java
+++ b/src/main/java/com/team/cops_and_robbers/auth/application/dto/command/AdminLoginCommand.java
@@ -1,0 +1,9 @@
+package com.team.cops_and_robbers.auth.application.dto.command;
+
+import com.team.cops_and_robbers.user.domain.SocialType;
+
+public record AdminLoginCommand(
+        SocialType socialType,
+        String idToken
+) {
+}

--- a/src/main/java/com/team/cops_and_robbers/auth/application/dto/result/AdminLoginResult.java
+++ b/src/main/java/com/team/cops_and_robbers/auth/application/dto/result/AdminLoginResult.java
@@ -1,0 +1,16 @@
+package com.team.cops_and_robbers.auth.application.dto.result;
+
+import com.team.cops_and_robbers.auth.domain.Tokens;
+import com.team.cops_and_robbers.user.domain.Role;
+import com.team.cops_and_robbers.user.domain.User;
+
+public record AdminLoginResult(
+        Long userId,
+        String nickname,
+        Role role,
+        Tokens tokens
+) {
+    public static AdminLoginResult of(User user, Tokens tokens) {
+        return new AdminLoginResult(user.getId(), user.getNickname(), user.getRole(), tokens);
+    }
+}

--- a/src/main/java/com/team/cops_and_robbers/auth/infrastructure/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/team/cops_and_robbers/auth/infrastructure/jwt/JwtTokenProvider.java
@@ -44,6 +44,7 @@ public class JwtTokenProvider {
 
         return Jwts.builder()
                 .setSubject(user.getId().toString())
+                .claim("role", user.getRole().name())
                 .setIssuedAt(now)
                 .setExpiration(expirationTime)
                 .signWith(accessKey)
@@ -55,6 +56,10 @@ public class JwtTokenProvider {
                 getAccessClaims(accessToken)
                         .getSubject()
         );
+    }
+
+    public String getRoleFromAccessToken(String accessToken) {
+        return getAccessClaims(accessToken).get("role", String.class);
     }
 
     private Claims getAccessClaims(String accessToken) {

--- a/src/main/java/com/team/cops_and_robbers/auth/presentation/AuthController.java
+++ b/src/main/java/com/team/cops_and_robbers/auth/presentation/AuthController.java
@@ -1,12 +1,15 @@
 package com.team.cops_and_robbers.auth.presentation;
 
 import com.team.cops_and_robbers.auth.application.AuthService;
+import com.team.cops_and_robbers.auth.application.dto.result.AdminLoginResult;
 import com.team.cops_and_robbers.auth.application.dto.result.LoginResult;
 import com.team.cops_and_robbers.auth.domain.Tokens;
+import com.team.cops_and_robbers.auth.presentation.dto.request.AdminLoginRequest;
 import com.team.cops_and_robbers.auth.presentation.dto.request.LoginRequest;
 import com.team.cops_and_robbers.auth.presentation.dto.request.ReissueRequest;
-import com.team.cops_and_robbers.auth.presentation.dto.response.LoginResponse;
 import com.team.cops_and_robbers.auth.presentation.dto.request.LogoutRequest;
+import com.team.cops_and_robbers.auth.presentation.dto.response.AdminLoginResponse;
+import com.team.cops_and_robbers.auth.presentation.dto.response.LoginResponse;
 import com.team.cops_and_robbers.auth.presentation.dto.response.ReissueResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -54,6 +57,25 @@ public class AuthController implements AuthControllerDocs {
     @PostMapping("/logout")
     public ResponseEntity<Void> logout(@RequestBody @Valid LogoutRequest request) {
         authService.logout(request.refreshToken());
+        return ResponseEntity.noContent().build();
+    }
+
+    /**
+     * 4. 어드민 웹 로그인을 진행합니다.
+     */
+    @PostMapping("/admin/login")
+    public ResponseEntity<AdminLoginResponse> adminLogin(@RequestBody @Valid AdminLoginRequest request) {
+        AdminLoginResult result = authService.adminLogin(request.toCommand());
+        AdminLoginResponse response = AdminLoginResponse.from(result);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 5. 어드민 웹 로그아웃을 진행합니다.
+     */
+    @PostMapping("/admin/logout")
+    public ResponseEntity<Void> adminLogout(@RequestBody @Valid LogoutRequest request) {
+        authService.adminLogout(request.refreshToken());
         return ResponseEntity.noContent().build();
     }
 

--- a/src/main/java/com/team/cops_and_robbers/auth/presentation/dto/request/AdminLoginRequest.java
+++ b/src/main/java/com/team/cops_and_robbers/auth/presentation/dto/request/AdminLoginRequest.java
@@ -1,0 +1,22 @@
+package com.team.cops_and_robbers.auth.presentation.dto.request;
+
+import com.team.cops_and_robbers.auth.application.dto.command.AdminLoginCommand;
+import com.team.cops_and_robbers.user.domain.SocialType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record AdminLoginRequest(
+
+        @Schema(description = "소셜 플랫폼", example = "GOOGLE")
+        @NotNull(message = "소셜 플랫폼 정보는 필수입니다.")
+        SocialType socialPlatform,
+
+        @Schema(description = "소셜 인증 ID 토큰", example = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9...")
+        @NotBlank(message = "소셜 인증 토큰(ID Token)은 필수입니다.")
+        String idToken
+) {
+    public AdminLoginCommand toCommand() {
+        return new AdminLoginCommand(socialPlatform, idToken);
+    }
+}

--- a/src/main/java/com/team/cops_and_robbers/auth/presentation/dto/response/AdminLoginResponse.java
+++ b/src/main/java/com/team/cops_and_robbers/auth/presentation/dto/response/AdminLoginResponse.java
@@ -1,0 +1,26 @@
+package com.team.cops_and_robbers.auth.presentation.dto.response;
+
+import com.team.cops_and_robbers.auth.application.dto.result.AdminLoginResult;
+import com.team.cops_and_robbers.auth.domain.Tokens;
+import com.team.cops_and_robbers.user.domain.Role;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record AdminLoginResponse(
+        @Schema(description = "유저 ID", example = "1")
+        Long userId,
+        @Schema(description = "닉네임", example = "민첩한괴도5308")
+        String nickname,
+        @Schema(description = "권한", example = "ADMIN")
+        Role role,
+        @Schema(description = "JWT 토큰 정보")
+        Tokens tokens
+) {
+    public static AdminLoginResponse from(AdminLoginResult result) {
+        return new AdminLoginResponse(
+                result.userId(),
+                result.nickname(),
+                result.role(),
+                result.tokens()
+        );
+    }
+}

--- a/src/main/java/com/team/cops_and_robbers/common/config/GraphQlConfig.java
+++ b/src/main/java/com/team/cops_and_robbers/common/config/GraphQlConfig.java
@@ -1,0 +1,15 @@
+package com.team.cops_and_robbers.common.config;
+
+import graphql.scalars.ExtendedScalars;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.graphql.execution.RuntimeWiringConfigurer;
+
+@Configuration
+public class GraphQlConfig {
+
+    @Bean
+    public RuntimeWiringConfigurer runtimeWiringConfigurer() {
+        return wiringBuilder -> wiringBuilder.scalar(ExtendedScalars.DateTime);
+    }
+}

--- a/src/main/java/com/team/cops_and_robbers/common/config/WebConfig.java
+++ b/src/main/java/com/team/cops_and_robbers/common/config/WebConfig.java
@@ -1,5 +1,6 @@
 package com.team.cops_and_robbers.common.config;
 
+import com.team.cops_and_robbers.admin.presentation.interceptor.AdminInterceptor;
 import com.team.cops_and_robbers.auth.presentation.interceptor.AuthInterceptor;
 import com.team.cops_and_robbers.auth.presentation.resolver.LoginUserArgumentResolver;
 import lombok.RequiredArgsConstructor;
@@ -15,6 +16,7 @@ import java.util.List;
 public class WebConfig implements WebMvcConfigurer {
 
     private final AuthInterceptor authInterceptor;
+    private final AdminInterceptor adminInterceptor;
     private final LoginUserArgumentResolver loginUserArgumentResolver;
 
     @Override
@@ -27,6 +29,9 @@ public class WebConfig implements WebMvcConfigurer {
                         "/api/user/check-nickname",
                         "/actuator/health"
                 );
+
+        registry.addInterceptor(adminInterceptor)
+                .addPathPatterns("/graphql");
     }
 
     @Override

--- a/src/main/java/com/team/cops_and_robbers/common/config/WebConfig.java
+++ b/src/main/java/com/team/cops_and_robbers/common/config/WebConfig.java
@@ -6,6 +6,7 @@ import com.team.cops_and_robbers.auth.presentation.resolver.LoginUserArgumentRes
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -32,6 +33,19 @@ public class WebConfig implements WebMvcConfigurer {
 
         registry.addInterceptor(adminInterceptor)
                 .addPathPatterns("/graphql");
+    }
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/graphql")
+                .allowedOrigins(
+                        "http://localhost:3000",
+                        "https://copsnro66ers.site",
+                        "https://admin.copsnro66ers.site"
+                )
+                .allowedMethods("POST", "OPTIONS")
+                .allowedHeaders("*")
+                .allowCredentials(true);
     }
 
     @Override

--- a/src/main/java/com/team/cops_and_robbers/common/config/WebConfig.java
+++ b/src/main/java/com/team/cops_and_robbers/common/config/WebConfig.java
@@ -46,6 +46,16 @@ public class WebConfig implements WebMvcConfigurer {
                 .allowedMethods("POST", "OPTIONS")
                 .allowedHeaders("*")
                 .allowCredentials(true);
+
+        registry.addMapping("/api/auth/**")
+                .allowedOrigins(
+                        "http://localhost:3000",
+                        "https://copsnro66ers.site",
+                        "https://admin.copsnro66ers.site"
+                )
+                .allowedMethods("POST", "OPTIONS")
+                .allowedHeaders("*")
+                .allowCredentials(true);
     }
 
     @Override

--- a/src/main/java/com/team/cops_and_robbers/common/util/TimestampUtil.java
+++ b/src/main/java/com/team/cops_and_robbers/common/util/TimestampUtil.java
@@ -21,4 +21,11 @@ public class TimestampUtil {
     public static String toIsoString(LocalDateTime localDateTime) {
         return localDateTime.atZone(KST).toOffsetDateTime().toString();
     }
+
+    // 외부 입력용: ISO 8601 문자열 -> KST 기준 LocalDateTime 변환
+    public static LocalDateTime parseToKstLocalDateTime(String isoString) {
+        return OffsetDateTime.parse(isoString)
+                .atZoneSameInstant(KST)
+                .toLocalDateTime();
+    }
 }

--- a/src/main/java/com/team/cops_and_robbers/common/util/TimestampUtil.java
+++ b/src/main/java/com/team/cops_and_robbers/common/util/TimestampUtil.java
@@ -28,4 +28,12 @@ public class TimestampUtil {
                 .atZoneSameInstant(KST)
                 .toLocalDateTime();
     }
+
+    // GraphQL DateTime 스칼라용: OffsetDateTime -> KST 기준 LocalDateTime 변환
+    public static LocalDateTime toKstLocalDateTime(OffsetDateTime offsetDateTime) {
+        if (offsetDateTime == null) {
+            return null;
+        }
+        return offsetDateTime.atZoneSameInstant(KST).toLocalDateTime();
+    }
 }

--- a/src/main/java/com/team/cops_and_robbers/game/area/repository/GameAreaRepository.java
+++ b/src/main/java/com/team/cops_and_robbers/game/area/repository/GameAreaRepository.java
@@ -8,11 +8,14 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface GameAreaRepository extends JpaRepository <GameArea, Long>{
 
     Optional<GameArea> findByGameId(Long gameId);
+
+    List<GameArea> findByGameIdIn(List<Long> gameIds);
 
     @Modifying(clearAutomatically = true)
     @Query("delete from GameArea ga where ga.game.id = :gameId")

--- a/src/main/java/com/team/cops_and_robbers/game/game/repository/GameRepository.java
+++ b/src/main/java/com/team/cops_and_robbers/game/game/repository/GameRepository.java
@@ -5,6 +5,8 @@ import com.team.cops_and_robbers.game.game.domain.Game;
 import com.team.cops_and_robbers.game.game.domain.GameStatus;
 import com.team.cops_and_robbers.game.game.exception.GameException;
 import com.team.cops_and_robbers.game.participant.exception.GameParticipantException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -24,6 +26,15 @@ public interface GameRepository extends JpaRepository<Game, Long> {
     List<Game> findByStatus(GameStatus status);
 
     Optional<Game> findByInviteCode(String inviteCode);
+
+    @Query("""
+            select g from Game g
+            where (:status is null or g.status = :status)
+            """)
+    Page<Game> findAllForAdmin(
+            @Param("status") GameStatus status,
+            Pageable pageable
+    );
 
     default Game getByGameId(Long gameId) {
         return findById(gameId)

--- a/src/main/java/com/team/cops_and_robbers/game/participant/repository/GameParticipantCountProjection.java
+++ b/src/main/java/com/team/cops_and_robbers/game/participant/repository/GameParticipantCountProjection.java
@@ -1,0 +1,6 @@
+package com.team.cops_and_robbers.game.participant.repository;
+
+public record GameParticipantCountProjection(
+        Long gameId,
+        Long count
+) {}

--- a/src/main/java/com/team/cops_and_robbers/game/participant/repository/GameParticipantRepository.java
+++ b/src/main/java/com/team/cops_and_robbers/game/participant/repository/GameParticipantRepository.java
@@ -171,6 +171,34 @@ public interface GameParticipantRepository extends JpaRepository<GameParticipant
     Optional<GameParticipant> findFirstByGameIdOrderByCreatedAtAsc(Long gameId);
 
     @Query("""
+        select gp
+        from GameParticipant gp
+        join fetch gp.game
+        join fetch gp.user
+        where gp.user.id in :userIds
+        """)
+    List<GameParticipant> findByUserIdInWithGame(@Param("userIds") List<Long> userIds);
+
+    @Query("""
+        select gp
+        from GameParticipant gp
+        join fetch gp.user
+        join fetch gp.game
+        where gp.game.id in :gameIds
+        """)
+    List<GameParticipant> findByGameIdInWithUser(@Param("gameIds") List<Long> gameIds);
+
+    @Query("""
+        select new com.team.cops_and_robbers.game.participant.repository.GameParticipantCountProjection(
+            gp.game.id, count(gp)
+        )
+        from GameParticipant gp
+        where gp.game.id in :gameIds
+        group by gp.game.id
+        """)
+    List<GameParticipantCountProjection> countByGameIdIn(@Param("gameIds") List<Long> gameIds);
+
+    @Query("""
         select new com.team.cops_and_robbers.game.participant.repository.GameParticipantCacheProjection(
             gp.id, gp.user.nickname, gp.team, ud.fcmToken
         )

--- a/src/main/java/com/team/cops_and_robbers/history/repository/GameResultRepository.java
+++ b/src/main/java/com/team/cops_and_robbers/history/repository/GameResultRepository.java
@@ -3,6 +3,12 @@ package com.team.cops_and_robbers.history.repository;
 import com.team.cops_and_robbers.history.domain.GameResult;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+import java.util.Optional;
+
 public interface GameResultRepository extends JpaRepository<GameResult, Long> {
 
+    Optional<GameResult> findByGameId(Long gameId);
+
+    List<GameResult> findByGameIdIn(List<Long> gameIds);
 }

--- a/src/main/java/com/team/cops_and_robbers/user/repository/UserDeviceRepository.java
+++ b/src/main/java/com/team/cops_and_robbers/user/repository/UserDeviceRepository.java
@@ -7,11 +7,15 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface UserDeviceRepository extends JpaRepository<UserDevice, Long> {
 
     Optional<UserDevice> findByUser(User user);
+
+    @Query("select ud from UserDevice ud join fetch ud.user where ud.user.id in :userIds")
+    List<UserDevice> findByUser_IdIn(@Param("userIds") List<Long> userIds);
 
     @Modifying(clearAutomatically = true)
     @Query("delete from UserDevice ud where ud.user.id = :userId")

--- a/src/main/java/com/team/cops_and_robbers/user/repository/UserRepository.java
+++ b/src/main/java/com/team/cops_and_robbers/user/repository/UserRepository.java
@@ -4,11 +4,14 @@ import com.team.cops_and_robbers.common.exception.ApplicationException;
 import com.team.cops_and_robbers.user.domain.SocialType;
 import com.team.cops_and_robbers.user.domain.User;
 import com.team.cops_and_robbers.user.exception.UserException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
@@ -20,6 +23,21 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByNickname(String nickname);
 
     Optional<User> findBySocialIdAndSocialType(String socialId, SocialType socialType);
+
+    @Query("""
+            select u from User u
+            where (:nickname is null or u.nickname like concat('%', :nickname, '%'))
+            and (:socialType is null or u.socialType = :socialType)
+            and (cast(:fromDate as timestamp) is null or u.createdAt >= :fromDate)
+            and (cast(:toDate as timestamp) is null or u.createdAt <= :toDate)
+            """)
+    Page<User> findAllForAdmin(
+            @Param("nickname") String nickname,
+            @Param("socialType") SocialType socialType,
+            @Param("fromDate") LocalDateTime fromDate,
+            @Param("toDate") LocalDateTime toDate,
+            Pageable pageable
+    );
 
     default User getByUserId(Long userId) {
         return findById(userId)

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -13,6 +13,10 @@ spring:
         dialect: org.hibernate.dialect.PostgreSQLDialect
         format_sql: false
 
+  graphql:
+    graphiql:
+      enabled: true
+
   flyway:
     enabled: true
     out-of-order: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,6 +5,10 @@ spring:
   lifecycle:
     timeout-per-shutdown-phase: 60s
 
+  graphql:
+    graphiql:
+      enabled: false
+
   flyway:
     enabled: true
     locations: classpath:db/migration

--- a/src/main/resources/graphql/schema.graphqls
+++ b/src/main/resources/graphql/schema.graphqls
@@ -115,9 +115,6 @@ type GameResult {
   totalRobberCount: Int!
   arrestedRobberCount: Int!
   durationSeconds: Int!
-  playgroundCenterLat: Float!
-  playgroundCenterLng: Float!
-  playgroundRadiusInMeters: Int!
 }
 
 type GameArea {

--- a/src/main/resources/graphql/schema.graphqls
+++ b/src/main/resources/graphql/schema.graphqls
@@ -1,3 +1,5 @@
+scalar DateTime
+
 # ─── 쿼리 진입점 ────────────────────────────────────────────
 type Query {
   # 유저 관리
@@ -6,8 +8,8 @@ type Query {
     size: Int = 20
     nickname: String
     socialType: SocialType
-    fromDate: String
-    toDate: String
+    fromDate: DateTime
+    toDate: DateTime
     sortDirection: SortDirection = DESC
   ): AdminUserPage!
 

--- a/src/main/resources/graphql/schema.graphqls
+++ b/src/main/resources/graphql/schema.graphqls
@@ -1,0 +1,141 @@
+# ─── 쿼리 진입점 ────────────────────────────────────────────
+type Query {
+  # 유저 관리
+  adminUsers(
+    page: Int = 0
+    size: Int = 20
+    nickname: String
+    socialType: SocialType
+    fromDate: String
+    toDate: String
+    sortDirection: SortDirection = DESC
+  ): AdminUserPage!
+
+  adminUser(id: ID!): AdminUser!
+
+  # 게임 결과 조회
+  adminGames(
+    page: Int = 0
+    size: Int = 20
+    status: GameStatus
+    sortDirection: SortDirection = DESC
+  ): AdminGamePage!
+
+  adminGame(id: ID!): AdminGame!
+}
+
+# ─── 정렬/방향 공통 ──────────────────────────────────────────
+enum SortDirection { ASC DESC }
+
+# ─── 유저 ────────────────────────────────────────────────────
+type AdminUserPage {
+  content: [AdminUser!]!
+  totalElements: Int!
+  totalPages: Int!
+  page: Int!
+  size: Int!
+}
+
+type AdminUser {
+  id: ID!
+  nickname: String!
+  socialType: SocialType!
+  role: Role!
+  termsOfServiceAgreed: Boolean!
+  privacyPolicyAgreed: Boolean!
+  locationTermsAgreed: Boolean!
+  createdAt: String!
+  device: UserDevice
+  participations: [GameParticipation!]!
+}
+
+type UserDevice {
+  deviceType: DeviceType!
+  createdAt: String!
+}
+
+type GameParticipation {
+  gameId: ID!
+  inviteCode: String!
+  team: Team
+  status: ParticipantStatus!
+  isHost: Boolean!
+  createdAt: String!
+}
+
+# ─── 게임 ────────────────────────────────────────────────────
+type AdminGamePage {
+  content: [AdminGameSummary!]!
+  totalElements: Int!
+  totalPages: Int!
+  page: Int!
+  size: Int!
+}
+
+type AdminGameSummary {
+  id: ID!
+  inviteCode: String!
+  status: GameStatus!
+  roundDurationMinutes: Int!
+  locationRevealIntervalMinutes: Int!
+  maxParticipants: Int!
+  isEventGame: Boolean!
+  participantCount: Int!
+  createdAt: String!
+}
+
+type AdminGame {
+  id: ID!
+  inviteCode: String!
+  status: GameStatus!
+  roundDurationMinutes: Int!
+  locationRevealIntervalMinutes: Int!
+  policeWaitMinutes: Int!
+  maxParticipants: Int!
+  isEventGame: Boolean!
+  createdAt: String!
+  startedAt: String
+  participants: [AdminParticipant!]!
+  result: GameResult
+  area: GameArea
+}
+
+type AdminParticipant {
+  userId: ID!
+  nickname: String!
+  team: Team
+  status: ParticipantStatus!
+  isHost: Boolean!
+}
+
+type GameResult {
+  winnerTeam: Team!
+  endReason: GameEndReason!
+  totalPoliceCount: Int!
+  totalRobberCount: Int!
+  arrestedRobberCount: Int!
+  durationSeconds: Int!
+  playgroundCenterLat: Float!
+  playgroundCenterLng: Float!
+  playgroundRadiusInMeters: Int!
+}
+
+type GameArea {
+  playgroundCenterLat: Float!
+  playgroundCenterLng: Float!
+  playgroundRadiusInMeters: Int!
+  jailCenterLat: Float!
+  jailCenterLng: Float!
+  jailRadiusInMeters: Int!
+}
+
+# ─── Enums ──────────────────────────────────
+enum SocialType { KAKAO GOOGLE APPLE }
+enum Role { USER ADMIN }
+enum DeviceType { IOS ANDROID }
+enum Team { POLICE ROBBER }
+
+enum ParticipantStatus { WAITING ALIVE JAILED POLICE_WAITING }
+enum GameStatus { WAITING IN_PROGRESS FINISHED CANCELED }
+
+enum GameEndReason { ALL_ARRESTED TIME_OVER POLICE_FORFEITED ROBBER_FORFEITED }

--- a/src/main/resources/graphql/schema.graphqls
+++ b/src/main/resources/graphql/schema.graphqls
@@ -118,15 +118,26 @@ type GameResult {
 }
 
 type GameArea {
-  playgroundCenterLat: Float!
-  playgroundCenterLng: Float!
-  playgroundRadiusInMeters: Int!
-  jailCenterLat: Float!
-  jailCenterLng: Float!
-  jailRadiusInMeters: Int!
+  areaType: AreaType!
+  # 원형 구역 (CIRCLE 전용, POLYGON일 때 null)
+  playgroundCenterLat: Float
+  playgroundCenterLng: Float
+  playgroundRadiusInMeters: Int
+  jailCenterLat: Float
+  jailCenterLng: Float
+  jailRadiusInMeters: Int
+  # 다각형 구역 (POLYGON 전용, CIRCLE일 때 null)
+  playgroundPolygon: [Coordinate!]
+  jailPolygon: [Coordinate!]
+}
+
+type Coordinate {
+  latitude: Float!
+  longitude: Float!
 }
 
 # ─── Enums ──────────────────────────────────
+enum AreaType { CIRCLE POLYGON }
 enum SocialType { KAKAO GOOGLE APPLE }
 enum Role { USER ADMIN }
 enum DeviceType { IOS ANDROID }

--- a/src/test/java/com/team/cops_and_robbers/admin/application/AdminGameServiceTest.java
+++ b/src/test/java/com/team/cops_and_robbers/admin/application/AdminGameServiceTest.java
@@ -1,0 +1,322 @@
+package com.team.cops_and_robbers.admin.application;
+
+import com.team.cops_and_robbers.admin.application.dto.SortDirection;
+import com.team.cops_and_robbers.admin.application.dto.command.AdminGameListCommand;
+import com.team.cops_and_robbers.admin.application.dto.result.AdminGamePageResult;
+import com.team.cops_and_robbers.admin.application.dto.result.AdminGameResult;
+import com.team.cops_and_robbers.admin.application.dto.result.AdminGameResultDetail;
+import com.team.cops_and_robbers.admin.application.dto.result.AdminGameAreaResult;
+import com.team.cops_and_robbers.admin.application.dto.result.AdminParticipantResult;
+import com.team.cops_and_robbers.common.ServiceUnitTest;
+import com.team.cops_and_robbers.common.fixture.GameAreaFixture;
+import com.team.cops_and_robbers.common.fixture.GameFixture;
+import com.team.cops_and_robbers.common.fixture.GameParticipantFixture;
+import com.team.cops_and_robbers.common.fixture.GameResultFixture;
+import com.team.cops_and_robbers.common.fixture.UserFixture;
+import com.team.cops_and_robbers.game.area.domain.GameArea;
+import com.team.cops_and_robbers.game.game.domain.Game;
+import com.team.cops_and_robbers.game.game.domain.GameStatus;
+import com.team.cops_and_robbers.game.participant.domain.GameParticipant;
+import com.team.cops_and_robbers.game.participant.repository.GameParticipantCountProjection;
+import com.team.cops_and_robbers.history.domain.GameResult;
+import com.team.cops_and_robbers.user.domain.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyList;
+import static org.mockito.Mockito.isNull;
+
+class AdminGameServiceTest extends ServiceUnitTest {
+
+    @InjectMocks
+    private AdminGameService adminGameService;
+
+    private Game game1;
+    private Game game2;
+
+    @BeforeEach
+    void setUp() {
+        game1 = GameFixture.FINISHED_GAME();
+        setId(game1, 1L);
+
+        game2 = GameFixture.WAITING_GAME();
+        setId(game2, 2L);
+    }
+
+    @Nested
+    @DisplayName("게임 목록 조회")
+    class GetGameList {
+
+        @Test
+        void 필터_없이_게임_목록을_조회하면_전체_게임_페이지를_반환한다() {
+            // given
+            AdminGameListCommand command = new AdminGameListCommand(0, 10, null, SortDirection.DESC);
+            Page<Game> gamePage = new PageImpl<>(List.of(game1, game2), PageRequest.of(0, 10), 2);
+            given(gameRepository.findAllForAdmin(isNull(), any())).willReturn(gamePage);
+            given(gameParticipantRepository.countByGameIdIn(List.of(1L, 2L)))
+                    .willReturn(List.of(
+                            new GameParticipantCountProjection(1L, 3L),
+                            new GameParticipantCountProjection(2L, 5L)
+                    ));
+
+            // when
+            AdminGamePageResult result = adminGameService.getGameList(command);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(result.totalElements()).isEqualTo(2);
+                softly.assertThat(result.content()).hasSize(2);
+                softly.assertThat(result.content().get(0).participantCount()).isEqualTo(3);
+                softly.assertThat(result.content().get(1).participantCount()).isEqualTo(5);
+            });
+        }
+
+        @Test
+        void 상태_필터로_게임_목록을_조회하면_해당_상태_게임만_반환한다() {
+            // given
+            AdminGameListCommand command = new AdminGameListCommand(0, 10, GameStatus.FINISHED, SortDirection.DESC);
+            Page<Game> gamePage = new PageImpl<>(List.of(game1), PageRequest.of(0, 10), 1);
+            given(gameRepository.findAllForAdmin(any(GameStatus.class), any())).willReturn(gamePage);
+            given(gameParticipantRepository.countByGameIdIn(List.of(1L)))
+                    .willReturn(List.of(new GameParticipantCountProjection(1L, 3L)));
+
+            // when
+            AdminGamePageResult result = adminGameService.getGameList(command);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(result.totalElements()).isEqualTo(1);
+                softly.assertThat(result.content().get(0).status()).isEqualTo(GameStatus.FINISHED);
+            });
+        }
+
+        @Test
+        void 참여자가_없는_게임은_참여자_수가_0으로_반환된다() {
+            // given
+            AdminGameListCommand command = new AdminGameListCommand(0, 10, null, SortDirection.DESC);
+            Page<Game> gamePage = new PageImpl<>(List.of(game1), PageRequest.of(0, 10), 1);
+            given(gameRepository.findAllForAdmin(isNull(), any())).willReturn(gamePage);
+            given(gameParticipantRepository.countByGameIdIn(List.of(1L))).willReturn(List.of());
+
+            // when
+            AdminGamePageResult result = adminGameService.getGameList(command);
+
+            // then
+            assertThat(result.content().get(0).participantCount()).isZero();
+        }
+
+        @Test
+        void 결과가_없으면_빈_페이지를_반환한다() {
+            // given
+            AdminGameListCommand command = new AdminGameListCommand(0, 10, GameStatus.IN_PROGRESS, SortDirection.ASC);
+            Page<Game> emptyPage = new PageImpl<>(List.of(), PageRequest.of(0, 10), 0);
+            given(gameRepository.findAllForAdmin(any(GameStatus.class), any())).willReturn(emptyPage);
+            given(gameParticipantRepository.countByGameIdIn(List.of())).willReturn(List.of());
+
+            // when
+            AdminGamePageResult result = adminGameService.getGameList(command);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(result.totalElements()).isZero();
+                softly.assertThat(result.content()).isEmpty();
+            });
+        }
+    }
+
+    @Nested
+    @DisplayName("게임 단건 조회")
+    class GetGame {
+
+        @Test
+        void 게임_아이디로_게임을_조회하면_해당_게임_정보를_반환한다() {
+            // given
+            given(gameRepository.getByGameId(1L)).willReturn(game1);
+
+            // when
+            AdminGameResult result = adminGameService.getGame(1L);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(result.id()).isEqualTo(1L);
+                softly.assertThat(result.status()).isEqualTo(GameStatus.FINISHED);
+            });
+        }
+    }
+
+    @Nested
+    @DisplayName("게임별 참여자 배치 조회")
+    class GetParticipantsByGame {
+
+        @Test
+        void 참여자가_있는_게임의_참여자_목록을_반환한다() {
+            // given
+            User user = UserFixture.USER("player1");
+            setId(user, 10L);
+
+            GameParticipant participant = GameParticipantFixture.HOST_PARTICIPANT(game1, user);
+            setId(participant, 100L);
+
+            AdminGameResult adminGame1 = AdminGameResult.from(game1);
+            AdminGameResult adminGame2 = AdminGameResult.from(game2);
+            List<AdminGameResult> games = List.of(adminGame1, adminGame2);
+
+            given(gameParticipantRepository.findByGameIdInWithUser(List.of(1L, 2L)))
+                    .willReturn(List.of(participant));
+
+            // when
+            Map<AdminGameResult, List<AdminParticipantResult>> result =
+                    adminGameService.getParticipantsByGame(games);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(result).hasSize(2);
+                softly.assertThat(result.get(adminGame1)).hasSize(1);
+                softly.assertThat(result.get(adminGame2)).isEmpty();
+            });
+        }
+
+        @Test
+        void 참여자가_없는_게임은_빈_리스트를_반환한다() {
+            // given
+            AdminGameResult adminGame = AdminGameResult.from(game1);
+            given(gameParticipantRepository.findByGameIdInWithUser(anyList())).willReturn(List.of());
+
+            // when
+            Map<AdminGameResult, List<AdminParticipantResult>> result =
+                    adminGameService.getParticipantsByGame(List.of(adminGame));
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(result).hasSize(1);
+                softly.assertThat(result.get(adminGame)).isEmpty();
+            });
+        }
+
+        @Test
+        void 한_게임에_여러_참여자가_있는_경우_모두_반환한다() {
+            // given
+            User user1 = UserFixture.USER("player1");
+            setId(user1, 10L);
+            User user2 = UserFixture.KAKAO_USER();
+            setId(user2, 11L);
+
+            GameParticipant participant1 = GameParticipantFixture.HOST_PARTICIPANT(game1, user1);
+            setId(participant1, 100L);
+            GameParticipant participant2 = GameParticipantFixture.GUEST_PARTICIPANT(game1, user2);
+            setId(participant2, 101L);
+
+            AdminGameResult adminGame = AdminGameResult.from(game1);
+            given(gameParticipantRepository.findByGameIdInWithUser(List.of(1L)))
+                    .willReturn(List.of(participant1, participant2));
+
+            // when
+            Map<AdminGameResult, List<AdminParticipantResult>> result =
+                    adminGameService.getParticipantsByGame(List.of(adminGame));
+
+            // then
+            assertThat(result.get(adminGame)).hasSize(2);
+        }
+    }
+
+    @Nested
+    @DisplayName("게임별 결과 배치 조회")
+    class GetResultsByGame {
+
+        @Test
+        void 결과가_있는_게임만_결과_맵에_포함된다() {
+            // given
+            GameResult gameResult = GameResultFixture.POLICE_WIN_RESULT(1L);
+
+            AdminGameResult adminGame1 = AdminGameResult.from(game1);
+            AdminGameResult adminGame2 = AdminGameResult.from(game2);
+            List<AdminGameResult> games = List.of(adminGame1, adminGame2);
+
+            given(gameResultRepository.findByGameIdIn(List.of(1L, 2L)))
+                    .willReturn(List.of(gameResult));
+
+            // when
+            Map<AdminGameResult, AdminGameResultDetail> result =
+                    adminGameService.getResultsByGame(games);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(result).hasSize(1);
+                softly.assertThat(result).containsKey(adminGame1);
+                softly.assertThat(result).doesNotContainKey(adminGame2);
+            });
+        }
+
+        @Test
+        void 결과가_없으면_빈_맵을_반환한다() {
+            // given
+            AdminGameResult adminGame = AdminGameResult.from(game1);
+            given(gameResultRepository.findByGameIdIn(anyList())).willReturn(List.of());
+
+            // when
+            Map<AdminGameResult, AdminGameResultDetail> result =
+                    adminGameService.getResultsByGame(List.of(adminGame));
+
+            // then
+            assertThat(result).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("게임별 구역 배치 조회")
+    class GetAreasByGame {
+
+        @Test
+        void 구역이_있는_게임만_구역_맵에_포함된다() {
+            // given
+            GameArea gameArea = GameAreaFixture.GAME_AREA(game1);
+
+            AdminGameResult adminGame1 = AdminGameResult.from(game1);
+            AdminGameResult adminGame2 = AdminGameResult.from(game2);
+            List<AdminGameResult> games = List.of(adminGame1, adminGame2);
+
+            given(gameAreaRepository.findByGameIdIn(List.of(1L, 2L)))
+                    .willReturn(List.of(gameArea));
+
+            // when
+            Map<AdminGameResult, AdminGameAreaResult> result =
+                    adminGameService.getAreasByGame(games);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(result).hasSize(1);
+                softly.assertThat(result).containsKey(adminGame1);
+                softly.assertThat(result).doesNotContainKey(adminGame2);
+            });
+        }
+
+        @Test
+        void 구역이_없으면_빈_맵을_반환한다() {
+            // given
+            AdminGameResult adminGame = AdminGameResult.from(game1);
+            given(gameAreaRepository.findByGameIdIn(anyList())).willReturn(List.of());
+
+            // when
+            Map<AdminGameResult, AdminGameAreaResult> result =
+                    adminGameService.getAreasByGame(List.of(adminGame));
+
+            // then
+            assertThat(result).isEmpty();
+        }
+    }
+}

--- a/src/test/java/com/team/cops_and_robbers/admin/application/AdminGameServiceTest.java
+++ b/src/test/java/com/team/cops_and_robbers/admin/application/AdminGameServiceTest.java
@@ -4,7 +4,7 @@ import com.team.cops_and_robbers.admin.application.dto.SortDirection;
 import com.team.cops_and_robbers.admin.application.dto.command.AdminGameListCommand;
 import com.team.cops_and_robbers.admin.application.dto.result.AdminGamePageResult;
 import com.team.cops_and_robbers.admin.application.dto.result.AdminGameResult;
-import com.team.cops_and_robbers.admin.application.dto.result.AdminGameResultDetail;
+import com.team.cops_and_robbers.admin.application.dto.result.AdminGameDetailResult;
 import com.team.cops_and_robbers.admin.application.dto.result.AdminGameAreaResult;
 import com.team.cops_and_robbers.admin.application.dto.result.AdminParticipantResult;
 import com.team.cops_and_robbers.common.ServiceUnitTest;
@@ -251,7 +251,7 @@ class AdminGameServiceTest extends ServiceUnitTest {
                     .willReturn(List.of(gameResult));
 
             // when
-            Map<AdminGameResult, AdminGameResultDetail> result =
+            Map<AdminGameResult, AdminGameDetailResult> result =
                     adminGameService.getResultsByGame(games);
 
             // then
@@ -269,7 +269,7 @@ class AdminGameServiceTest extends ServiceUnitTest {
             given(gameResultRepository.findByGameIdIn(anyList())).willReturn(List.of());
 
             // when
-            Map<AdminGameResult, AdminGameResultDetail> result =
+            Map<AdminGameResult, AdminGameDetailResult> result =
                     adminGameService.getResultsByGame(List.of(adminGame));
 
             // then

--- a/src/test/java/com/team/cops_and_robbers/admin/application/AdminGameServiceTest.java
+++ b/src/test/java/com/team/cops_and_robbers/admin/application/AdminGameServiceTest.java
@@ -284,7 +284,7 @@ class AdminGameServiceTest extends ServiceUnitTest {
         @Test
         void 구역이_있는_게임만_구역_맵에_포함된다() {
             // given
-            GameArea gameArea = GameAreaFixture.GAME_AREA(game1);
+            GameArea gameArea = GameAreaFixture.CIRCLE_GAME_AREA(game1);
 
             AdminGameResult adminGame1 = AdminGameResult.from(game1);
             AdminGameResult adminGame2 = AdminGameResult.from(game2);

--- a/src/test/java/com/team/cops_and_robbers/admin/application/AdminUserServiceTest.java
+++ b/src/test/java/com/team/cops_and_robbers/admin/application/AdminUserServiceTest.java
@@ -1,0 +1,306 @@
+package com.team.cops_and_robbers.admin.application;
+
+import com.team.cops_and_robbers.admin.application.dto.SortDirection;
+import com.team.cops_and_robbers.admin.application.dto.command.AdminUserListCommand;
+import com.team.cops_and_robbers.admin.application.dto.result.AdminUserPageResult;
+import com.team.cops_and_robbers.admin.application.dto.result.AdminUserResult;
+import com.team.cops_and_robbers.admin.application.dto.result.GameParticipationResult;
+import com.team.cops_and_robbers.admin.application.dto.result.UserDeviceResult;
+import com.team.cops_and_robbers.common.ServiceUnitTest;
+import com.team.cops_and_robbers.common.fixture.GameFixture;
+import com.team.cops_and_robbers.common.fixture.GameParticipantFixture;
+import com.team.cops_and_robbers.common.fixture.UserDeviceFixture;
+import com.team.cops_and_robbers.common.fixture.UserFixture;
+import com.team.cops_and_robbers.game.game.domain.Game;
+import com.team.cops_and_robbers.game.participant.domain.GameParticipant;
+import com.team.cops_and_robbers.user.domain.User;
+import com.team.cops_and_robbers.user.domain.UserDevice;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyList;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.isNull;
+
+class AdminUserServiceTest extends ServiceUnitTest {
+
+    @InjectMocks
+    private AdminUserService adminUserService;
+
+    private User user1;
+    private User user2;
+
+    @BeforeEach
+    void setUp() {
+        user1 = UserFixture.USER("user1");
+        setId(user1, 1L);
+        ReflectionTestUtils.setField(user1, "createdAt", LocalDateTime.now());
+
+        user2 = UserFixture.KAKAO_USER();
+        setId(user2, 2L);
+        ReflectionTestUtils.setField(user2, "createdAt", LocalDateTime.now());
+    }
+
+    @Nested
+    @DisplayName("유저 목록 조회")
+    class GetUserList {
+
+        @Test
+        void 필터_없이_유저_목록을_조회하면_전체_유저_페이지를_반환한다() {
+            // given
+            AdminUserListCommand command = new AdminUserListCommand(
+                    0, 10, null, null, null, null, SortDirection.DESC);
+            Page<User> userPage = new PageImpl<>(List.of(user1, user2), PageRequest.of(0, 10), 2);
+            given(userRepository.findAllForAdmin(isNull(), isNull(), isNull(), isNull(), any()))
+                    .willReturn(userPage);
+
+            // when
+            AdminUserPageResult result = adminUserService.getUserList(command);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(result.totalElements()).isEqualTo(2);
+                softly.assertThat(result.content()).hasSize(2);
+                softly.assertThat(result.content().get(0).nickname()).isEqualTo("user1");
+            });
+        }
+
+        @Test
+        void 닉네임_필터로_유저_목록을_조회하면_해당_닉네임_유저만_반환한다() {
+            // given
+            AdminUserListCommand command = new AdminUserListCommand(
+                    0, 10, "user1", null, null, null, SortDirection.DESC);
+            Page<User> userPage = new PageImpl<>(List.of(user1), PageRequest.of(0, 10), 1);
+            given(userRepository.findAllForAdmin(eq("user1"), isNull(), isNull(), isNull(), any()))
+                    .willReturn(userPage);
+
+            // when
+            AdminUserPageResult result = adminUserService.getUserList(command);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(result.totalElements()).isEqualTo(1);
+                softly.assertThat(result.content().get(0).nickname()).isEqualTo("user1");
+            });
+        }
+
+        @Test
+        void fromDate_toDate_필터로_유저_목록을_조회하면_해당_기간의_유저만_반환한다() {
+            // given
+            AdminUserListCommand command = new AdminUserListCommand(
+                    0, 10, null, null,
+                    LocalDateTime.of(2024, 1, 1, 0, 0, 0),
+                    LocalDateTime.of(2024, 12, 31, 23, 59, 59),
+                    SortDirection.ASC);
+            Page<User> userPage = new PageImpl<>(List.of(user1), PageRequest.of(0, 10), 1);
+            given(userRepository.findAllForAdmin(isNull(), isNull(), any(LocalDateTime.class), any(LocalDateTime.class), any()))
+                    .willReturn(userPage);
+
+            // when
+            AdminUserPageResult result = adminUserService.getUserList(command);
+
+            // then
+            assertThat(result.totalElements()).isEqualTo(1);
+        }
+
+        @Test
+        void 결과가_없으면_빈_페이지를_반환한다() {
+            // given
+            AdminUserListCommand command = new AdminUserListCommand(
+                    0, 10, "존재하지않는닉네임", null, null, null, SortDirection.DESC);
+            Page<User> emptyPage = new PageImpl<>(List.of(), PageRequest.of(0, 10), 0);
+            given(userRepository.findAllForAdmin(anyString(), isNull(), isNull(), isNull(), any()))
+                    .willReturn(emptyPage);
+
+            // when
+            AdminUserPageResult result = adminUserService.getUserList(command);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(result.totalElements()).isZero();
+                softly.assertThat(result.content()).isEmpty();
+            });
+        }
+    }
+
+    @Nested
+    @DisplayName("유저 단건 조회")
+    class GetUser {
+
+        @Test
+        void 유저_아이디로_유저를_조회하면_해당_유저_정보를_반환한다() {
+            // given
+            given(userRepository.getByUserId(1L)).willReturn(user1);
+
+            // when
+            AdminUserResult result = adminUserService.getUser(1L);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(result.id()).isEqualTo(1L);
+                softly.assertThat(result.nickname()).isEqualTo("user1");
+                softly.assertThat(result.socialType()).isEqualTo(user1.getSocialType());
+            });
+        }
+    }
+
+    @Nested
+    @DisplayName("유저별 디바이스 배치 조회")
+    class GetDevicesByUsers {
+
+        @Test
+        void 디바이스가_있는_유저는_디바이스_정보가_포함된다() {
+            // given
+            UserDevice device = UserDeviceFixture.IOS_DEVICE(user1);
+            ReflectionTestUtils.setField(device, "createdAt", LocalDateTime.now());
+            AdminUserResult adminUser1 = AdminUserResult.from(user1);
+            AdminUserResult adminUser2 = AdminUserResult.from(user2);
+            List<AdminUserResult> users = List.of(adminUser1, adminUser2);
+
+            given(userDeviceRepository.findByUser_IdIn(List.of(1L, 2L)))
+                    .willReturn(List.of(device));
+
+            // when
+            Map<AdminUserResult, UserDeviceResult> result = adminUserService.getDevicesByUsers(users);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(result).hasSize(1);
+                softly.assertThat(result).containsKey(adminUser1);
+                softly.assertThat(result).doesNotContainKey(adminUser2);
+            });
+        }
+
+        @Test
+        void 디바이스가_없는_유저는_결과_맵에_포함되지_않는다() {
+            // given
+            AdminUserResult adminUser = AdminUserResult.from(user1);
+            given(userDeviceRepository.findByUser_IdIn(anyList())).willReturn(List.of());
+
+            // when
+            Map<AdminUserResult, UserDeviceResult> result = adminUserService.getDevicesByUsers(List.of(adminUser));
+
+            // then
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        void 여러_유저의_디바이스를_한번에_조회한다() {
+            // given
+            UserDevice device1 = UserDeviceFixture.IOS_DEVICE(user1);
+            ReflectionTestUtils.setField(device1, "createdAt", LocalDateTime.now());
+            UserDevice device2 = UserDeviceFixture.ANDROID_DEVICE(user2);
+            ReflectionTestUtils.setField(device2, "createdAt", LocalDateTime.now());
+            AdminUserResult adminUser1 = AdminUserResult.from(user1);
+            AdminUserResult adminUser2 = AdminUserResult.from(user2);
+            List<AdminUserResult> users = List.of(adminUser1, adminUser2);
+
+            given(userDeviceRepository.findByUser_IdIn(List.of(1L, 2L)))
+                    .willReturn(List.of(device1, device2));
+
+            // when
+            Map<AdminUserResult, UserDeviceResult> result = adminUserService.getDevicesByUsers(users);
+
+            // then
+            assertThat(result).hasSize(2);
+        }
+    }
+
+    @Nested
+    @DisplayName("유저별 게임 참여 이력 배치 조회")
+    class GetGameParticipationsByUsers {
+
+        @Test
+        void 게임_참여_이력이_있는_유저의_참여_정보를_반환한다() {
+            // given
+            Game game = GameFixture.FINISHED_GAME();
+            setId(game, 10L);
+            ReflectionTestUtils.setField(game, "createdAt", LocalDateTime.now());
+
+            GameParticipant participant = GameParticipantFixture.HOST_PARTICIPANT(game, user1);
+            setId(participant, 100L);
+            ReflectionTestUtils.setField(participant, "createdAt", LocalDateTime.now());
+
+            AdminUserResult adminUser1 = AdminUserResult.from(user1);
+            AdminUserResult adminUser2 = AdminUserResult.from(user2);
+            List<AdminUserResult> users = List.of(adminUser1, adminUser2);
+
+            given(gameParticipantRepository.findByUserIdInWithGame(List.of(1L, 2L)))
+                    .willReturn(List.of(participant));
+
+            // when
+            Map<AdminUserResult, List<GameParticipationResult>> result =
+                    adminUserService.getGameParticipationsByUsers(users);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(result).hasSize(2);
+                softly.assertThat(result.get(adminUser1)).hasSize(1);
+                softly.assertThat(result.get(adminUser2)).isEmpty();
+            });
+        }
+
+        @Test
+        void 게임_참여_이력이_없으면_빈_리스트를_반환한다() {
+            // given
+            AdminUserResult adminUser = AdminUserResult.from(user1);
+            given(gameParticipantRepository.findByUserIdInWithGame(anyList())).willReturn(List.of());
+
+            // when
+            Map<AdminUserResult, List<GameParticipationResult>> result =
+                    adminUserService.getGameParticipationsByUsers(List.of(adminUser));
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(result).hasSize(1);
+                softly.assertThat(result.get(adminUser)).isEmpty();
+            });
+        }
+
+        @Test
+        void 한_유저가_여러_게임에_참여한_경우_모두_반환한다() {
+            // given
+            Game game1 = GameFixture.FINISHED_GAME();
+            setId(game1, 10L);
+            ReflectionTestUtils.setField(game1, "createdAt", LocalDateTime.now());
+
+            Game game2 = GameFixture.FINISHED_GAME();
+            setId(game2, 11L);
+            ReflectionTestUtils.setField(game2, "createdAt", LocalDateTime.now());
+
+            GameParticipant participant1 = GameParticipantFixture.GUEST_PARTICIPANT(game1, user1);
+            setId(participant1, 100L);
+            ReflectionTestUtils.setField(participant1, "createdAt", LocalDateTime.now());
+            GameParticipant participant2 = GameParticipantFixture.GUEST_PARTICIPANT(game2, user1);
+            setId(participant2, 101L);
+            ReflectionTestUtils.setField(participant2, "createdAt", LocalDateTime.now());
+
+            AdminUserResult adminUser = AdminUserResult.from(user1);
+            given(gameParticipantRepository.findByUserIdInWithGame(List.of(1L)))
+                    .willReturn(List.of(participant1, participant2));
+
+            // when
+            Map<AdminUserResult, List<GameParticipationResult>> result =
+                    adminUserService.getGameParticipationsByUsers(List.of(adminUser));
+
+            // then
+            assertThat(result.get(adminUser)).hasSize(2);
+        }
+    }
+}

--- a/src/test/java/com/team/cops_and_robbers/admin/presentation/AdminGameResolverTest.java
+++ b/src/test/java/com/team/cops_and_robbers/admin/presentation/AdminGameResolverTest.java
@@ -1,0 +1,251 @@
+package com.team.cops_and_robbers.admin.presentation;
+
+import com.team.cops_and_robbers.common.ControllerTest;
+import com.team.cops_and_robbers.common.fixture.GameAreaFixture;
+import com.team.cops_and_robbers.common.fixture.GameFixture;
+import com.team.cops_and_robbers.common.fixture.GameParticipantFixture;
+import com.team.cops_and_robbers.common.fixture.GameResultFixture;
+import com.team.cops_and_robbers.game.game.domain.Game;
+import com.team.cops_and_robbers.user.domain.User;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+class AdminGameResolverTest extends ControllerTest {
+
+    private static final String GRAPHQL_URL = "/graphql";
+
+    private String adminToken;
+
+    @BeforeEach
+    void setUpAdmin() {
+        adminToken = givenAccessToken(givenAdminUser("admin"));
+    }
+
+    @Nested
+    @DisplayName("인증 검사")
+    class Authentication {
+
+        @Test
+        void 토큰_없이_요청하면_401을_반환한다() {
+            // when
+            ExtractableResponse<Response> response = executeQuery(
+                    "{ adminGames { totalElements content { id status } } }");
+
+            // then
+            assertThat(response.statusCode()).isEqualTo(401);
+        }
+
+        @Test
+        void 일반_유저_토큰으로_요청하면_403을_반환한다() {
+            // given
+            User user = givenUser("normalUser");
+            String userToken = givenAccessToken(user);
+
+            // when
+            ExtractableResponse<Response> response = executeQuery(
+                    userToken, "{ adminGames { totalElements content { id status } } }");
+
+            // then
+            assertThat(response.statusCode()).isEqualTo(403);
+        }
+    }
+
+    @Nested
+    @DisplayName("게임 목록 조회")
+    class AdminGames {
+
+        @Test
+        void 게임_목록을_페이지로_조회한다() {
+            // given
+            gameRepository.save(GameFixture.FINISHED_GAME());
+            gameRepository.save(GameFixture.WAITING_GAME());
+
+            // when
+            ExtractableResponse<Response> response = executeQuery(
+                    adminToken,
+                    "{ adminGames(page: 0, size: 10) { totalElements totalPages page size content { id inviteCode status participantCount } } }");
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(response.statusCode()).isEqualTo(200);
+                softly.assertThat((Integer) response.jsonPath().get("data.adminGames.totalElements")).isGreaterThanOrEqualTo(2);
+                softly.assertThat(response.jsonPath().getList("data.adminGames.content")).isNotEmpty();
+            });
+        }
+
+        @Test
+        void 상태로_게임을_필터링한다() {
+            // given
+            gameRepository.save(GameFixture.FINISHED_GAME());
+            gameRepository.save(GameFixture.WAITING_GAME());
+
+            // when
+            ExtractableResponse<Response> response = executeQuery(
+                    adminToken,
+                    "{ adminGames(status: FINISHED) { totalElements content { id status } } }");
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(response.statusCode()).isEqualTo(200);
+                softly.assertThat((Integer) response.jsonPath().get("data.adminGames.totalElements")).isGreaterThanOrEqualTo(1);
+                softly.assertThat(response.jsonPath().getString("data.adminGames.content[0].status")).isEqualTo("FINISHED");
+            });
+        }
+
+        @Test
+        void 결과가_없으면_빈_목록을_반환한다() {
+            // when
+            ExtractableResponse<Response> response = executeQuery(
+                    adminToken,
+                    "{ adminGames(status: IN_PROGRESS) { totalElements content { id } } }");
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(response.statusCode()).isEqualTo(200);
+                softly.assertThat((Integer) response.jsonPath().get("data.adminGames.totalElements")).isZero();
+                softly.assertThat(response.jsonPath().getList("data.adminGames.content")).isEmpty();
+            });
+        }
+    }
+
+    @Nested
+    @DisplayName("게임 단건 조회")
+    class AdminGame {
+
+        @Test
+        void 게임_아이디로_단건_조회한다() {
+            // given
+            Game game = gameRepository.save(GameFixture.FINISHED_GAME());
+
+            // when
+            ExtractableResponse<Response> response = executeQuery(
+                    adminToken,
+                    "{ adminGame(id: " + game.getId() + ") { id inviteCode status roundDurationMinutes maxParticipants } }");
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(response.statusCode()).isEqualTo(200);
+                softly.assertThat(response.jsonPath().getString("data.adminGame.id")).isEqualTo(String.valueOf(game.getId()));
+                softly.assertThat(response.jsonPath().getString("data.adminGame.status")).isEqualTo("FINISHED");
+            });
+        }
+
+        @Test
+        void 참여자_목록을_포함하여_조회한다() {
+            // given
+            Game game = gameRepository.save(GameFixture.FINISHED_GAME());
+            User user = givenUser("participant");
+            gameParticipantRepository.save(GameParticipantFixture.HOST_PARTICIPANT(game, user));
+
+            // when
+            ExtractableResponse<Response> response = executeQuery(
+                    adminToken,
+                    "{ adminGame(id: " + game.getId() + ") { id participants { userId nickname team status isHost } } }");
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(response.statusCode()).isEqualTo(200);
+                softly.assertThat(response.jsonPath().getList("data.adminGame.participants")).hasSize(1);
+                softly.assertThat(response.jsonPath().getString("data.adminGame.participants[0].nickname")).isEqualTo("participant");
+                softly.assertThat((Boolean) response.jsonPath().get("data.adminGame.participants[0].isHost")).isTrue();
+            });
+        }
+
+        @Test
+        void 게임_결과를_포함하여_조회한다() {
+            // given
+            Game game = gameRepository.save(GameFixture.FINISHED_GAME());
+            gameResultRepository.save(GameResultFixture.POLICE_WIN_RESULT(game.getId()));
+
+            // when
+            ExtractableResponse<Response> response = executeQuery(
+                    adminToken,
+                    "{ adminGame(id: " + game.getId() + ") { id result { winnerTeam endReason totalPoliceCount totalRobberCount durationSeconds } } }");
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(response.statusCode()).isEqualTo(200);
+                softly.assertThat(response.jsonPath().getString("data.adminGame.result.winnerTeam")).isEqualTo("POLICE");
+                softly.assertThat(response.jsonPath().getString("data.adminGame.result.endReason")).isEqualTo("ALL_ARRESTED");
+            });
+        }
+
+        @Test
+        void 게임_결과가_없으면_result가_null이다() {
+            // given
+            Game game = gameRepository.save(GameFixture.WAITING_GAME());
+
+            // when
+            ExtractableResponse<Response> response = executeQuery(
+                    adminToken,
+                    "{ adminGame(id: " + game.getId() + ") { id result { winnerTeam } } }");
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(response.statusCode()).isEqualTo(200);
+                softly.assertThat((Object) response.jsonPath().get("data.adminGame.result")).isNull();
+            });
+        }
+
+        @Test
+        void 게임_구역을_포함하여_조회한다() {
+            // given
+            Game game = gameRepository.save(GameFixture.FINISHED_GAME());
+            gameAreaRepository.save(GameAreaFixture.GAME_AREA(game));
+
+            // when
+            ExtractableResponse<Response> response = executeQuery(
+                    adminToken,
+                    "{ adminGame(id: " + game.getId() + ") { id area { playgroundCenterLat playgroundCenterLng playgroundRadiusInMeters jailCenterLat jailCenterLng jailRadiusInMeters } } }");
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(response.statusCode()).isEqualTo(200);
+                softly.assertThat((Object) response.jsonPath().get("data.adminGame.area")).isNotNull();
+                softly.assertThat((Integer) response.jsonPath().get("data.adminGame.area.playgroundRadiusInMeters")).isEqualTo(500);
+            });
+        }
+
+        @Test
+        void 게임_구역이_없으면_area가_null이다() {
+            // given
+            Game game = gameRepository.save(GameFixture.WAITING_GAME());
+
+            // when
+            ExtractableResponse<Response> response = executeQuery(
+                    adminToken,
+                    "{ adminGame(id: " + game.getId() + ") { id area { playgroundRadiusInMeters } } }");
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(response.statusCode()).isEqualTo(200);
+                softly.assertThat((Object) response.jsonPath().get("data.adminGame.area")).isNull();
+            });
+        }
+    }
+
+    private ExtractableResponse<Response> executeQuery(String token, String query) {
+        return authenticated(token)
+                .body("{\"query\": \"" + query.replace("\"", "\\\"").replace("\n", " ") + "\"}")
+                .when()
+                .post(GRAPHQL_URL)
+                .then()
+                .extract();
+    }
+
+    private ExtractableResponse<Response> executeQuery(String query) {
+        return unauthenticated()
+                .body("{\"query\": \"" + query.replace("\"", "\\\"").replace("\n", " ") + "\"}")
+                .when()
+                .post(GRAPHQL_URL)
+                .then()
+                .extract();
+    }
+}

--- a/src/test/java/com/team/cops_and_robbers/admin/presentation/AdminGameResolverTest.java
+++ b/src/test/java/com/team/cops_and_robbers/admin/presentation/AdminGameResolverTest.java
@@ -198,12 +198,12 @@ class AdminGameResolverTest extends ControllerTest {
         void 게임_구역을_포함하여_조회한다() {
             // given
             Game game = gameRepository.save(GameFixture.FINISHED_GAME());
-            gameAreaRepository.save(GameAreaFixture.GAME_AREA(game));
+            gameAreaRepository.save(GameAreaFixture.CIRCLE_GAME_AREA(game));
 
             // when
             ExtractableResponse<Response> response = executeQuery(
                     adminToken,
-                    "{ adminGame(id: " + game.getId() + ") { id area { playgroundCenterLat playgroundCenterLng playgroundRadiusInMeters jailCenterLat jailCenterLng jailRadiusInMeters } } }");
+                    "{ adminGame(id: " + game.getId() + ") { id area { areaType playgroundCenterLat playgroundCenterLng playgroundRadiusInMeters jailCenterLat jailCenterLng jailRadiusInMeters } } }");
 
             // then
             assertSoftly(softly -> {

--- a/src/test/java/com/team/cops_and_robbers/admin/presentation/AdminUserResolverTest.java
+++ b/src/test/java/com/team/cops_and_robbers/admin/presentation/AdminUserResolverTest.java
@@ -1,0 +1,217 @@
+package com.team.cops_and_robbers.admin.presentation;
+
+import com.team.cops_and_robbers.common.ControllerTest;
+import com.team.cops_and_robbers.common.fixture.GameFixture;
+import com.team.cops_and_robbers.common.fixture.GameParticipantFixture;
+import com.team.cops_and_robbers.common.fixture.UserDeviceFixture;
+import com.team.cops_and_robbers.game.game.domain.Game;
+import com.team.cops_and_robbers.game.participant.domain.GameParticipant;
+import com.team.cops_and_robbers.user.domain.User;
+import com.team.cops_and_robbers.user.domain.UserDevice;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+class AdminUserResolverTest extends ControllerTest {
+
+    private static final String GRAPHQL_URL = "/graphql";
+
+    private String adminToken;
+
+    @BeforeEach
+    void setUpAdmin() {
+        adminToken = givenAccessToken(givenAdminUser("admin"));
+    }
+
+    @Nested
+    @DisplayName("인증 검사")
+    class Authentication {
+
+        @Test
+        void 토큰_없이_요청하면_401을_반환한다() {
+            // when
+            ExtractableResponse<Response> response = executeQuery(
+                    "{ adminUsers { totalElements content { id } } }");
+
+            // then
+            assertThat(response.statusCode()).isEqualTo(401);
+        }
+
+        @Test
+        void 일반_유저_토큰으로_요청하면_403을_반환한다() {
+            // given
+            User user = givenUser("normalUser");
+            String userToken = givenAccessToken(user);
+
+            // when
+            ExtractableResponse<Response> response = executeQuery(
+                    userToken, "{ adminUsers { totalElements content { id } } }");
+
+            // then
+            assertThat(response.statusCode()).isEqualTo(403);
+        }
+    }
+
+    @Nested
+    @DisplayName("유저 목록 조회")
+    class AdminUsers {
+
+        @Test
+        void 유저_목록을_페이지로_조회한다() {
+            // given
+            givenUser("user1");
+            givenUser("user2");
+
+            // when
+            ExtractableResponse<Response> response = executeQuery(
+                    adminToken,
+                    "{ adminUsers(page: 0, size: 10) { totalElements totalPages page size content { id nickname socialType role } } }");
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(response.statusCode()).isEqualTo(200);
+                softly.assertThat((Integer) response.jsonPath().get("data.adminUsers.totalElements")).isGreaterThanOrEqualTo(2);
+                softly.assertThat(response.jsonPath().getList("data.adminUsers.content")).isNotEmpty();
+            });
+        }
+
+        @Test
+        void 닉네임으로_유저를_필터링한다() {
+            // given
+            givenUser("uniqueNick");
+            givenUser("otherUser");
+
+            // when
+            ExtractableResponse<Response> response = executeQuery(
+                    adminToken,
+                    "{ adminUsers(nickname: \"uniqueNick\") { totalElements content { id nickname } } }");
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(response.statusCode()).isEqualTo(200);
+                softly.assertThat((Integer) response.jsonPath().get("data.adminUsers.totalElements")).isEqualTo(1);
+                softly.assertThat(response.jsonPath().getString("data.adminUsers.content[0].nickname")).isEqualTo("uniqueNick");
+            });
+        }
+
+        @Test
+        void 결과가_없으면_빈_목록을_반환한다() {
+            // when
+            ExtractableResponse<Response> response = executeQuery(
+                    adminToken,
+                    "{ adminUsers(nickname: \"존재하지않는닉네임\") { totalElements content { id } } }");
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(response.statusCode()).isEqualTo(200);
+                softly.assertThat((Integer) response.jsonPath().get("data.adminUsers.totalElements")).isZero();
+                softly.assertThat(response.jsonPath().getList("data.adminUsers.content")).isEmpty();
+            });
+        }
+    }
+
+    @Nested
+    @DisplayName("유저 단건 조회")
+    class AdminUser {
+
+        @Test
+        void 유저_아이디로_단건_조회한다() {
+            // given
+            User user = givenUser("targetUser");
+
+            // when
+            ExtractableResponse<Response> response = executeQuery(
+                    adminToken,
+                    "{ adminUser(id: " + user.getId() + ") { id nickname socialType role } }");
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(response.statusCode()).isEqualTo(200);
+                softly.assertThat(response.jsonPath().getString("data.adminUser.id")).isEqualTo(String.valueOf(user.getId()));
+                softly.assertThat(response.jsonPath().getString("data.adminUser.nickname")).isEqualTo("targetUser");
+            });
+        }
+
+        @Test
+        void 디바이스_정보를_포함하여_조회한다() {
+            // given
+            User user = givenUser("deviceUser");
+            UserDevice device = userDeviceRepository.save(UserDeviceFixture.IOS_DEVICE(user));
+
+            // when
+            ExtractableResponse<Response> response = executeQuery(
+                    adminToken,
+                    "{ adminUser(id: " + user.getId() + ") { id nickname device { deviceType } } }");
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(response.statusCode()).isEqualTo(200);
+                softly.assertThat(response.jsonPath().getString("data.adminUser.device.deviceType")).isEqualTo("IOS");
+            });
+        }
+
+        @Test
+        void 디바이스가_없는_유저는_device가_null이다() {
+            // given
+            User user = givenUser("noDeviceUser");
+
+            // when
+            ExtractableResponse<Response> response = executeQuery(
+                    adminToken,
+                    "{ adminUser(id: " + user.getId() + ") { id nickname device { deviceType } } }");
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(response.statusCode()).isEqualTo(200);
+                softly.assertThat((Object) response.jsonPath().get("data.adminUser.device")).isNull();
+            });
+        }
+
+        @Test
+        void 게임_참여_이력을_포함하여_조회한다() {
+            // given
+            User user = givenUser("participantUser");
+            Game game = gameRepository.save(GameFixture.FINISHED_GAME());
+            GameParticipant participant = gameParticipantRepository.save(
+                    GameParticipantFixture.HOST_PARTICIPANT(game, user));
+
+            // when
+            ExtractableResponse<Response> response = executeQuery(
+                    adminToken,
+                    "{ adminUser(id: " + user.getId() + ") { id nickname participations { gameId status isHost } } }");
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(response.statusCode()).isEqualTo(200);
+                softly.assertThat(response.jsonPath().getList("data.adminUser.participations")).hasSize(1);
+                softly.assertThat(response.jsonPath().getString("data.adminUser.participations[0].gameId"))
+                        .isEqualTo(String.valueOf(game.getId()));
+                softly.assertThat((Boolean) response.jsonPath().get("data.adminUser.participations[0].isHost")).isTrue();
+            });
+        }
+    }
+
+    private ExtractableResponse<Response> executeQuery(String token, String query) {
+        return authenticated(token)
+                .body("{\"query\": \"" + query.replace("\"", "\\\"").replace("\n", " ") + "\"}")
+                .when()
+                .post(GRAPHQL_URL)
+                .then()
+                .extract();
+    }
+
+    private ExtractableResponse<Response> executeQuery(String query) {
+        return unauthenticated()
+                .body("{\"query\": \"" + query.replace("\"", "\\\"").replace("\n", " ") + "\"}")
+                .when()
+                .post(GRAPHQL_URL)
+                .then()
+                .extract();
+    }
+}

--- a/src/test/java/com/team/cops_and_robbers/auth/application/AuthServiceTest.java
+++ b/src/test/java/com/team/cops_and_robbers/auth/application/AuthServiceTest.java
@@ -1,6 +1,8 @@
 package com.team.cops_and_robbers.auth.application;
 
+import com.team.cops_and_robbers.auth.application.dto.command.AdminLoginCommand;
 import com.team.cops_and_robbers.auth.application.dto.command.LoginCommand;
+import com.team.cops_and_robbers.auth.application.dto.result.AdminLoginResult;
 import com.team.cops_and_robbers.auth.application.dto.result.LoginResult;
 import com.team.cops_and_robbers.auth.application.event.UserFcmTokenUpdatedEvent;
 import com.team.cops_and_robbers.auth.domain.Tokens;
@@ -10,6 +12,7 @@ import com.team.cops_and_robbers.auth.repository.RefreshTokenRepository;
 import com.team.cops_and_robbers.common.ServiceUnitTest;
 import com.team.cops_and_robbers.common.exception.ApplicationException;
 import com.team.cops_and_robbers.user.domain.DeviceType;
+import com.team.cops_and_robbers.user.domain.Role;
 import com.team.cops_and_robbers.user.domain.SocialType;
 import com.team.cops_and_robbers.user.domain.User;
 import com.team.cops_and_robbers.user.domain.UserDevice;
@@ -251,6 +254,112 @@ class AuthServiceTest extends ServiceUnitTest {
             // then
             then(refreshTokenRepository).should(never()).delete(anyLong());
             then(userDeviceRepository).should(never()).deleteByUserId(anyLong());
+        }
+    }
+
+    @Nested
+    @DisplayName("어드민 웹 로그인")
+    class AdminLogin {
+
+        @Test
+        void ADMIN_권한_유저라면_디바이스_동기화_없이_토큰을_발급한다() {
+            // given
+            AdminLoginCommand command = new AdminLoginCommand(SocialType.KAKAO, "admin_token");
+            String socialId = "admin_social_123";
+
+            User adminUser = User.signUp(socialId, SocialType.KAKAO, "admin_nick");
+            setId(adminUser, 1L);
+            ReflectionTestUtils.setField(adminUser, "role", Role.ADMIN);
+
+            when(socialLoginStrategy.validateAndGetSocialId(anyString())).thenReturn(socialId);
+            when(userRepository.findBySocialIdAndSocialType(socialId, SocialType.KAKAO))
+                    .thenReturn(Optional.of(adminUser));
+            when(jwtTokenProvider.createAccessToken(any())).thenReturn("access");
+            when(jwtTokenProvider.createRefreshToken(any())).thenReturn("refresh");
+
+            // when
+            AdminLoginResult result = authService.adminLogin(command);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(result.userId()).isEqualTo(1L);
+                softly.assertThat(result.nickname()).isEqualTo("admin_nick");
+                softly.assertThat(result.role()).isEqualTo(Role.ADMIN);
+                softly.assertThat(result.tokens().accessToken()).isEqualTo("access");
+                softly.assertThat(result.tokens().refreshToken()).isEqualTo("refresh");
+            });
+            then(userDeviceRepository).should(never()).findByUser(any());
+            then(userDeviceRepository).should(never()).save(any());
+        }
+
+        @Test
+        void ADMIN_권한이_아닌_유저라면_예외가_발생한다() {
+            // given
+            AdminLoginCommand command = new AdminLoginCommand(SocialType.KAKAO, "user_token");
+            String socialId = "user_social_123";
+
+            User normalUser = User.signUp(socialId, SocialType.KAKAO, "normal_nick");
+            setId(normalUser, 2L);
+
+            when(socialLoginStrategy.validateAndGetSocialId(anyString())).thenReturn(socialId);
+            when(userRepository.findBySocialIdAndSocialType(socialId, SocialType.KAKAO))
+                    .thenReturn(Optional.of(normalUser));
+
+            // when & then
+            assertThatThrownBy(() -> authService.adminLogin(command))
+                    .isInstanceOf(ApplicationException.class);
+
+            then(jwtTokenProvider).should(never()).createAccessToken(any());
+        }
+
+        @Test
+        void 미가입_유저라면_예외가_발생한다() {
+            // given
+            AdminLoginCommand command = new AdminLoginCommand(SocialType.KAKAO, "unknown_token");
+            String socialId = "unknown_social_123";
+
+            when(socialLoginStrategy.validateAndGetSocialId(anyString())).thenReturn(socialId);
+            when(userRepository.findBySocialIdAndSocialType(socialId, SocialType.KAKAO))
+                    .thenReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> authService.adminLogin(command))
+                    .isInstanceOf(ApplicationException.class);
+
+            then(jwtTokenProvider).should(never()).createAccessToken(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("어드민 웹 로그아웃")
+    class AdminLogout {
+
+        @Test
+        void 유효한_토큰으로_로그아웃_시_리프레시_토큰만_삭제하고_기기_정보는_유지한다() {
+            // given
+            String validToken = "valid_refresh_token";
+            Long userId = 1L;
+            when(jwtTokenProvider.getUserIdFromRefreshTokenLogout(validToken)).thenReturn(Optional.of(userId));
+
+            // when
+            authService.adminLogout(validToken);
+
+            // then
+            then(refreshTokenRepository).should().delete(userId);
+            then(userDeviceRepository).should(never()).deleteByUserId(anyLong());
+        }
+
+        @Test
+        void 유효하지_않은_토큰으로_로그아웃_시_아무_일도_일어나지_않는다() {
+            // given
+            String invalidToken = "invalid_token";
+            when(jwtTokenProvider.getUserIdFromRefreshTokenLogout(invalidToken)).thenReturn(Optional.empty());
+
+            // when
+            authService.adminLogout(invalidToken);
+
+            // then
+            then(refreshTokenRepository).should(never()).delete(anyLong());
         }
     }
 

--- a/src/test/java/com/team/cops_and_robbers/auth/presentation/AuthControllerTest.java
+++ b/src/test/java/com/team/cops_and_robbers/auth/presentation/AuthControllerTest.java
@@ -2,15 +2,18 @@ package com.team.cops_and_robbers.auth.presentation;
 
 import com.team.cops_and_robbers.auth.domain.Tokens;
 import com.team.cops_and_robbers.auth.exception.AuthException;
+import com.team.cops_and_robbers.auth.presentation.dto.request.AdminLoginRequest;
 import com.team.cops_and_robbers.auth.presentation.dto.request.LoginRequest;
 import com.team.cops_and_robbers.auth.presentation.dto.request.LogoutRequest;
 import com.team.cops_and_robbers.auth.presentation.dto.request.ReissueRequest;
+import com.team.cops_and_robbers.auth.presentation.dto.response.AdminLoginResponse;
 import com.team.cops_and_robbers.auth.presentation.dto.response.LoginResponse;
 import com.team.cops_and_robbers.auth.presentation.dto.response.ReissueResponse;
 import com.team.cops_and_robbers.common.ControllerTest;
 import com.team.cops_and_robbers.common.exception.CommonException;
 import com.team.cops_and_robbers.common.exception.ErrorResponse;
 import com.team.cops_and_robbers.user.domain.DeviceType;
+import com.team.cops_and_robbers.user.domain.Role;
 import com.team.cops_and_robbers.user.domain.SocialType;
 import com.team.cops_and_robbers.user.domain.User;
 import com.team.cops_and_robbers.user.domain.UserDevice;
@@ -189,6 +192,117 @@ class AuthControllerTest extends ControllerTest {
             assertSoftly(softly -> {
                 softly.assertThat(extract.statusCode()).isEqualTo(204);
                 String storedToken = refreshTokenRepository.findByUserId(user.getId());
+                softly.assertThat(storedToken).isNull();
+            });
+        }
+    }
+
+    @Nested
+    @DisplayName("어드민 웹 로그인 API")
+    class AdminLogin {
+
+        @Test
+        void ADMIN_유저라면_로그인_성공하고_200_OK를_응답해야_한다() {
+            // given
+            User adminUser = givenAdminUser();
+            doReturn(adminUser.getSocialId())
+                    .when(googleLoginStrategy)
+                    .validateAndGetSocialId(anyString());
+
+            AdminLoginRequest request = new AdminLoginRequest(SocialType.GOOGLE, "valid_token");
+
+            // when
+            ExtractableResponse<Response> extract = unauthenticated()
+                    .body(request)
+                    .when()
+                    .post("/api/auth/admin/login")
+                    .then()
+                    .extract();
+
+            // then
+            AdminLoginResponse response = extract.as(AdminLoginResponse.class);
+            assertSoftly(softly -> {
+                softly.assertThat(extract.statusCode()).isEqualTo(200);
+                softly.assertThat(response.userId()).isEqualTo(adminUser.getId());
+                softly.assertThat(response.nickname()).isEqualTo(adminUser.getNickname());
+                softly.assertThat(response.role()).isEqualTo(Role.ADMIN);
+                softly.assertThat(response.tokens().accessToken()).isNotNull();
+                softly.assertThat(response.tokens().refreshToken()).isNotNull();
+            });
+        }
+
+        @Test
+        void 일반_유저라면_403_FORBIDDEN을_응답해야_한다() {
+            // given
+            User normalUser = givenUser();
+            doReturn(normalUser.getSocialId())
+                    .when(googleLoginStrategy)
+                    .validateAndGetSocialId(anyString());
+
+            AdminLoginRequest request = new AdminLoginRequest(SocialType.GOOGLE, "valid_token");
+
+            // when
+            ExtractableResponse<Response> extract = unauthenticated()
+                    .body(request)
+                    .when()
+                    .post("/api/auth/admin/login")
+                    .then()
+                    .extract();
+
+            // then
+            ErrorResponse response = extract.as(ErrorResponse.class);
+            assertSoftly(softly -> {
+                softly.assertThat(extract.statusCode()).isEqualTo(403);
+                softly.assertThat(response.title()).isEqualTo(AuthException.FORBIDDEN_ADMIN_ONLY.getTitle());
+            });
+        }
+
+        @Test
+        void 필수_파라미터인_idToken이_누락되면_400_BAD_REQUEST를_응답해야_한다() {
+            // given
+            AdminLoginRequest request = new AdminLoginRequest(SocialType.GOOGLE, null);
+
+            // when
+            ExtractableResponse<Response> extract = unauthenticated()
+                    .body(request)
+                    .when()
+                    .post("/api/auth/admin/login")
+                    .then()
+                    .extract();
+
+            // then
+            ErrorResponse response = extract.as(ErrorResponse.class);
+            assertSoftly(softly -> {
+                softly.assertThat(extract.statusCode()).isEqualTo(400);
+                softly.assertThat(response.title()).isEqualTo(CommonException.INVALID_INPUT_VALUE.getTitle());
+                softly.assertThat(response.detail()).contains("idToken");
+            });
+        }
+    }
+
+    @Nested
+    @DisplayName("어드민 웹 로그아웃 API")
+    class AdminLogout {
+
+        @Test
+        void 로그아웃_요청이_성공하면_리프레시_토큰만_삭제하고_204_NO_CONTENT를_응답해야_한다() {
+            // given
+            User adminUser = givenAdminUser();
+            Tokens tokens = givenTokens(adminUser);
+            LogoutRequest request = new LogoutRequest(tokens.refreshToken());
+
+            // when
+            ExtractableResponse<Response> extract = unauthenticated()
+                    .body(request)
+                    .when()
+                    .post("/api/auth/admin/logout")
+                    .then()
+                    .extract();
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(extract.statusCode()).isEqualTo(204);
+                String storedToken = refreshTokenRepository.findByUserId(adminUser.getId());
                 softly.assertThat(storedToken).isNull();
             });
         }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -34,6 +34,7 @@ logging:
   level:
     org.hibernate.SQL: debug
     org.hibernate.type.descriptor.sql: trace
+    org.springframework.graphql: debug
 
 firebase:
   key-path: classpath:dummy-firebase-key.json


### PR DESCRIPTION
<h2><strong>📎 Issue 번호</strong></h2>
<ul>
<li>closed #115</li>
<li>closed #120</li>
</ul>
<h2><strong>✨ 작업 내용</strong></h2>
<p>어드민 대시보드에서 유저와 게임 결과를 조회할 수 있는 GraphQL API를 구현했습니다.</p>
<ul>
<li>GraphQL 스키마 정의 및 설정 추가</li>
<li>어드민 인증 인터셉터 구현 (토큰에 admin 롤 추가)</li>
<li>유저 조회 API(목록+단건) 추가</li>
<li>게임 조회 API(목록+단건) 추가</li>
</ul>
<h3><strong>조회 API 구조</strong></h3>
<p><strong>유저 조회</strong></p>

항목 | 설명
-- | --
목록 필터 | 닉네임, 소셜타입, 가입일 범위
단건 포함 정보 | 디바이스, 게임 참여 이력
<p><strong>게임 조회</strong></p>

항목 | 설명
-- | --
목록 필터 | 게임 상태(WAITING, IN_PROGRESS 등)
단건 포함 정보 | 참여자, 승패 결과, 구역

### 어드민 전용 로그인/로그아웃 API 추가
- POST `/api/auth/admin/login`, `/admin/logout`
- 모바일 로그인과 분리하여 device sync 없이 토큰만 발급
- 어드민 로그아웃 시 refreshToken만 삭제(앱 푸시용 device 레코드 유지)

<!-- notionvc: 5442f269-545a-412c-acac-2c88214a624b -->

<h2><strong>🎯 리뷰 포인트</strong></h2>
<p><strong>1. JWT role claim 방식</strong></p>
<p>어드민 인증 시 매번 DB 조회하는 대신 토큰 role을 claim에 넣고 꺼내 쓰는 방식으로 진행했습니다. 이 부분 괜찮은지 봐주시면 감사하겠습니다!</p>
<p><strong>2. 패키지 구조</strong></p>
<p>각 도메인 패키지에 어드민 로직을 넣는 것보다 <code>admin/</code> 패키지에서 통합 관리하는 게 유지보수 측면에서 나을 것 같아서 다음과 같이 구조를 잡았는데요, 더 나은 구조가 있을지에 대해서도 한번 봐주시면 감사하겠습니다 🙌🏻</p>
<pre><code>admin/
 ├─ application/
 │   ├─ AdminGameService
 │   ├─ AdminUserService
 │   └─ dto/
 │       ├─ command/
 │       ├─ result/
 │       └─ SortDirection
 ├─ exception/
 │   └─ AdminException
 └─ presentation/
     ├─ AdminGameResolver
     ├─ AdminUserResolver
     └─ interceptor/
         └─ AdminInterceptor
</code></pre>
<h2><strong>📝 기타</strong></h2>
<ul>
<li>폴리곤 타입 추가 PR이 머지되면 변경 필요한 부분들을 수정해서 반영해두겠습니다!</li>
<li>GraphQL 관련 설계 문서는 현재 작성 중이라 완료된 후 말씀드리겠습니당(완료)</li>
<li>더 자세한 내용은 #120 과 노션의 관리자 페이지 API 스팩에서 확인 가능합니다!!(로그인 설계 포함)</li>
</ul>
<h2><strong>✅ 테스트</strong></h2>
<ul>
<li>[x]  수동 테스트 완료</li>
<li>[x]  테스트 코드 완료</li>
</ul>
<!-- notionvc: a7879d0f-8cfe-4e6e-a891-9d764c49221d -->