### PR TITLE
fix: 폴리곤 게임 종료 시 폴리곤 스냅샷 지원 추가

### DIFF
--- a/src/main/java/com/team/cops_and_robbers/history/application/GameResultService.java
+++ b/src/main/java/com/team/cops_and_robbers/history/application/GameResultService.java
@@ -50,8 +50,7 @@ public class GameResultService {
                 totalRobber,
                 jailedCountAtEnd,
                 game.getTotalArrestCount(),
-                gameArea.getPlaygroundCenter(),
-                gameArea.getPlaygroundRadiusInMeters()
+                gameArea
         );
 
         return gameResultRepository.save(result);

--- a/src/main/java/com/team/cops_and_robbers/history/domain/GameResult.java
+++ b/src/main/java/com/team/cops_and_robbers/history/domain/GameResult.java
@@ -1,15 +1,25 @@
 package com.team.cops_and_robbers.history.domain;
 
 import com.team.cops_and_robbers.common.BaseTimeEntity;
+import com.team.cops_and_robbers.game.area.domain.AreaType;
+import com.team.cops_and_robbers.game.area.domain.GameArea;
 import com.team.cops_and_robbers.game.game.domain.Game;
 import com.team.cops_and_robbers.game.participant.domain.Team;
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Builder;
 import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.Polygon;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
@@ -52,11 +62,17 @@ public class GameResult extends BaseTimeEntity {
     @Column(nullable = false)
     private Integer durationSeconds;
 
-    @Column(nullable = false, columnDefinition = "GEOMETRY(POINT, 4326)")
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private AreaType areaType;
+
+    @Column(columnDefinition = "GEOMETRY(POINT, 4326)")
     private Point playgroundCenter;
 
-    @Column(nullable = false)
     private Integer playgroundRadiusInMeters;
+
+    @Column(columnDefinition = "GEOMETRY(POLYGON, 4326)")
+    private Polygon playgroundPolygon;
 
     public static GameResult createSnapshot(
             Game game,
@@ -66,14 +82,13 @@ public class GameResult extends BaseTimeEntity {
             Integer totalRobber,
             Integer jailedAtEnd,
             Integer totalArrestCount,
-            Point center,
-            Integer radius
+            GameArea gameArea
     ) {
         int durationSeconds = (int) Duration
                 .between(game.getStartedAt(), LocalDateTime.now())
                 .getSeconds();
 
-        return GameResult.builder()
+        GameResultBuilder builder = GameResult.builder()
                 .gameId(game.getId())
                 .winnerTeam(winningTeam)
                 .endReason(endReason)
@@ -82,8 +97,16 @@ public class GameResult extends BaseTimeEntity {
                 .arrestedRobberCount(jailedAtEnd)
                 .totalArrestCount(totalArrestCount)
                 .durationSeconds(durationSeconds)
-                .playgroundCenter(center)
-                .playgroundRadiusInMeters(radius)
-                .build();
+                .areaType(gameArea.getAreaType());
+
+        if (gameArea.getAreaType() == AreaType.CIRCLE) {
+            builder.playgroundCenter(gameArea.getPlaygroundCenter())
+                   .playgroundRadiusInMeters(gameArea.getPlaygroundRadiusInMeters());
+        }
+        else {
+            builder.playgroundPolygon(gameArea.getPlaygroundPolygon());
+        }
+
+        return builder.build();
     }
 }

--- a/src/main/resources/db/migration/V260729_1000__add_polygon_support_to_game_results.sql
+++ b/src/main/resources/db/migration/V260729_1000__add_polygon_support_to_game_results.sql
@@ -1,0 +1,6 @@
+ALTER TABLE game_results
+    ADD COLUMN area_type                VARCHAR(10)            NOT NULL DEFAULT 'CIRCLE',
+    ADD COLUMN playground_polygon       GEOMETRY(POLYGON, 4326),
+    ALTER COLUMN playground_center      DROP NOT NULL,
+    ALTER COLUMN playground_radius_in_meters DROP NOT NULL;
+

--- a/src/test/java/com/team/cops_and_robbers/common/e2e/LobbyE2ETest.java
+++ b/src/test/java/com/team/cops_and_robbers/common/e2e/LobbyE2ETest.java
@@ -17,6 +17,8 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 @Tag("e2e")
@@ -158,10 +160,11 @@ class LobbyE2ETest extends WebSocketE2ETest {
                 .then()
                 .statusCode(200);
 
-        // then
-        TestEventResponse guestEvent = setup.guestClient().waitForMessage(setup.lobbyChannel(), 5);
+        // then: 방장 퇴장 시 HOST_CHANGED + EXIT 두 이벤트가 발행됨
+        TestEventResponse event1 = setup.guestClient().waitForMessage(setup.lobbyChannel(), 5);
+        TestEventResponse event2 = setup.guestClient().waitForMessage(setup.lobbyChannel(), 5);
 
-        assertThat(guestEvent.type()).isEqualTo("HOST_CHANGED");
+        assertThat(List.of(event1.type(), event2.type())).contains("HOST_CHANGED");
     }
 
     @Nested

--- a/src/test/java/com/team/cops_and_robbers/common/e2e/LobbyE2ETest.java
+++ b/src/test/java/com/team/cops_and_robbers/common/e2e/LobbyE2ETest.java
@@ -13,6 +13,7 @@ import com.team.cops_and_robbers.play.lobby.presentation.dto.request.ReadyUpdate
 import com.team.cops_and_robbers.play.lobby.presentation.dto.request.TeamChangeRequest;
 import com.team.cops_and_robbers.user.domain.User;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -161,6 +162,55 @@ class LobbyE2ETest extends WebSocketE2ETest {
         TestEventResponse guestEvent = setup.guestClient().waitForMessage(setup.lobbyChannel(), 5);
 
         assertThat(guestEvent.type()).isEqualTo("HOST_CHANGED");
+    }
+
+    @Nested
+    @DisplayName("폴리곤 영역 로비 이벤트 E2E")
+    class WithPolygonArea {
+
+        private LobbySetup givenLobbySetupPolygon() throws Exception {
+            User hostUser = givenUser("polyHost");
+            User guestUser = givenUser("polyGuest");
+
+            Game game = gameRepository.save(GameFixture.WAITING_GAME());
+            gameAreaRepository.save(GameAreaFixture.POLYGON_GAME_AREA(game));
+            gameParticipantRepository.save(GameParticipantFixture.HOST_PARTICIPANT(game, hostUser));
+            gameParticipantRepository.save(GameParticipantFixture.GUEST_PARTICIPANT(game, guestUser));
+
+            return connectAndSubscribeLobby(game, hostUser, guestUser);
+        }
+
+        @Test
+        void 폴리곤_영역에서_유저가_퇴장하면_EXIT_이벤트를_수신한다() throws Exception {
+            // given
+            LobbySetup setup = givenLobbySetupPolygon();
+
+            // when
+            authenticated(setup.guestToken())
+                    .delete("/api/games/{gameId}/leave", setup.game().getId())
+                    .then()
+                    .statusCode(200);
+
+            // then
+            TestEventResponse hostEvent = setup.hostClient().waitForMessage(setup.lobbyChannel(), 5);
+            assertThat(hostEvent.type()).isEqualTo("EXIT");
+        }
+
+        @Test
+        void 폴리곤_영역에서_방장이_퇴장하면_HOST_CHANGED_이벤트를_수신한다() throws Exception {
+            // given
+            LobbySetup setup = givenLobbySetupPolygon();
+
+            // when
+            authenticated(setup.hostToken())
+                    .delete("/api/games/{gameId}/leave", setup.game().getId())
+                    .then()
+                    .statusCode(200);
+
+            // then
+            TestEventResponse guestEvent = setup.guestClient().waitForMessage(setup.lobbyChannel(), 5);
+            assertThat(guestEvent.type()).isEqualTo("HOST_CHANGED");
+        }
     }
 
     @Test

--- a/src/test/java/com/team/cops_and_robbers/common/e2e/LobbyE2ETest.java
+++ b/src/test/java/com/team/cops_and_robbers/common/e2e/LobbyE2ETest.java
@@ -211,8 +211,10 @@ class LobbyE2ETest extends WebSocketE2ETest {
                     .statusCode(200);
 
             // then
-            TestEventResponse guestEvent = setup.guestClient().waitForMessage(setup.lobbyChannel(), 5);
-            assertThat(guestEvent.type()).isEqualTo("HOST_CHANGED");
+            TestEventResponse event1 = setup.guestClient().waitForMessage(setup.lobbyChannel(), 5);
+            TestEventResponse event2 = setup.guestClient().waitForMessage(setup.lobbyChannel(), 5);
+
+            assertThat(List.of(event1.type(), event2.type())).contains("HOST_CHANGED");
         }
     }
 

--- a/src/test/java/com/team/cops_and_robbers/common/e2e/LocationE2ETest.java
+++ b/src/test/java/com/team/cops_and_robbers/common/e2e/LocationE2ETest.java
@@ -14,6 +14,7 @@ import com.team.cops_and_robbers.play.system.application.SystemPublisher;
 import com.team.cops_and_robbers.play.system.domain.SystemEventData;
 import com.team.cops_and_robbers.user.domain.User;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -85,6 +86,48 @@ class LocationE2ETest extends WebSocketE2ETest {
         assertThat(locations.get(0).participantId()).isEqualTo(setup.robberParticipant().getId());
         assertThat(locations.get(0).latitude()).isEqualTo(37.5);
         assertThat(locations.get(0).longitude()).isEqualTo(127.0);
+    }
+
+    @Nested
+    @DisplayName("폴리곤 영역 위치 이벤트 E2E")
+    class WithPolygonArea {
+
+        private LocationSetup givenLocationSetupPolygon() throws Exception {
+            User policeUser = givenUser("polyPolice");
+            User robberUser = givenUser("polyRobber");
+
+            Game game = gameRepository.save(GameFixture.IN_PROGRESS_GAME());
+            gameAreaRepository.save(GameAreaFixture.POLYGON_GAME_AREA(game));
+            givenPolice(game, policeUser);
+            GameParticipant robberParticipant = givenRobber(game, robberUser);
+
+            String policeToken = givenAccessToken(policeUser);
+            String robberToken = givenAccessToken(robberUser);
+            String systemChannel = SYSTEM_CHANNEL.formatted(game.getId());
+
+            StompTestClient policeClient = connect(policeToken);
+            StompTestClient robberClient = connect(robberToken);
+            policeClient.subscribe(systemChannel, TestEventResponse.class);
+            robberClient.subscribe(systemChannel, TestEventResponse.class);
+
+            return new LocationSetup(game, robberParticipant, policeToken, robberToken, systemChannel, policeClient, robberClient);
+        }
+
+        @Test
+        void 폴리곤_영역에서_도둑이_위치를_전송하면_서버에_위치가_저장된다() throws Exception {
+            // given
+            LocationSetup setup = givenLocationSetupPolygon();
+
+            // when
+            setup.robberClient().send("/publish/game/" + setup.game().getId() + "/location",
+                    new LocationUpdateRequest(37.5, 127.0));
+
+            Thread.sleep(500);
+
+            // then
+            List<SystemEventData.RobberLocation> locations = robberLocationService.revealRobberLocations(setup.game().getId());
+            assertThat(locations.get(0).participantId()).isEqualTo(setup.robberParticipant().getId());
+        }
     }
 
     @Test

--- a/src/test/java/com/team/cops_and_robbers/common/e2e/SystemE2ETest.java
+++ b/src/test/java/com/team/cops_and_robbers/common/e2e/SystemE2ETest.java
@@ -17,6 +17,7 @@ import com.team.cops_and_robbers.play.system.domain.SystemEventData;
 import com.team.cops_and_robbers.play.system.presentation.dto.request.ArrestRequest;
 import com.team.cops_and_robbers.user.domain.User;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -169,5 +170,69 @@ class SystemE2ETest extends WebSocketE2ETest {
 
         assertThat(arrestEvent.type()).isEqualTo("ARREST");
         assertThat(gameOverEvent.type()).isEqualTo("GAME_OVER");
+    }
+
+    @Nested
+    @DisplayName("폴리곤 영역 시스템 이벤트 E2E")
+    class WithPolygonArea {
+
+        private SystemSetup givenSystemSetupPolygon() throws Exception {
+            User policeUser = givenUser("polyPolice");
+            User robberUser = givenUser("polyRobber");
+
+            Game game = gameRepository.save(GameFixture.IN_PROGRESS_GAME());
+            gameAreaRepository.save(GameAreaFixture.POLYGON_GAME_AREA(game));
+            GameParticipant policeParticipant = givenPolice(game, policeUser);
+            GameParticipant robberParticipant = givenRobber(game, robberUser);
+
+            String policeToken = givenAccessToken(policeUser);
+            String robberToken = givenAccessToken(robberUser);
+            String systemChannel = SYSTEM_CHANNEL.formatted(game.getId());
+
+            StompTestClient policeClient = connect(policeToken);
+            StompTestClient robberClient = connect(robberToken);
+            policeClient.subscribe(systemChannel, TestEventResponse.class);
+            robberClient.subscribe(systemChannel, TestEventResponse.class);
+
+            return new SystemSetup(game, policeParticipant, robberParticipant, policeToken, robberToken, systemChannel, policeClient, robberClient);
+        }
+
+        @Test
+        void 폴리곤_영역에서_경찰이_도둑을_체포하면_ARREST_이벤트를_수신한다() throws Exception {
+            // given: 도둑 2명 (체포 후에도 게임 종료 안 됨)
+            SystemSetup setup = givenSystemSetupPolygon();
+            givenRobber(setup.game(), givenUser("polyRobber2"));
+
+            // when
+            authenticated(setup.policeToken())
+                    .body(new ArrestRequest(setup.robberParticipant().getId()))
+                    .post("/api/games/{gameId}/system/arrest", setup.game().getId())
+                    .then()
+                    .statusCode(200);
+
+            // then
+            TestEventResponse policeEvent = setup.policeClient().waitForMessage(setup.systemChannel(), 5);
+            assertThat(policeEvent.type()).isEqualTo("ARREST");
+        }
+
+        @Test
+        void 폴리곤_영역에서_모든_도둑이_체포되면_GAME_OVER_이벤트를_수신한다() throws Exception {
+            // given: 마지막 도둑 한 명 남음
+            SystemSetup setup = givenSystemSetupPolygon();
+
+            // when
+            authenticated(setup.policeToken())
+                    .body(new ArrestRequest(setup.robberParticipant().getId()))
+                    .post("/api/games/{gameId}/system/arrest", setup.game().getId())
+                    .then()
+                    .statusCode(200);
+
+            // then
+            TestEventResponse arrestEvent = setup.policeClient().waitForMessage(setup.systemChannel(), 5);
+            TestEventResponse gameOverEvent = setup.policeClient().waitForMessage(setup.systemChannel(), 5);
+
+            assertThat(arrestEvent.type()).isEqualTo("ARREST");
+            assertThat(gameOverEvent.type()).isEqualTo("GAME_OVER");
+        }
     }
 }

--- a/src/test/java/com/team/cops_and_robbers/common/fixture/GameResultFixture.java
+++ b/src/test/java/com/team/cops_and_robbers/common/fixture/GameResultFixture.java
@@ -1,11 +1,14 @@
 package com.team.cops_and_robbers.common.fixture;
 
+import com.team.cops_and_robbers.game.area.domain.AreaType;
 import com.team.cops_and_robbers.game.participant.domain.Team;
 import com.team.cops_and_robbers.history.domain.GameEndReason;
 import com.team.cops_and_robbers.history.domain.GameResult;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.LinearRing;
 import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.Polygon;
 import org.locationtech.jts.geom.PrecisionModel;
 
 public class GameResultFixture {
@@ -23,8 +26,38 @@ public class GameResultFixture {
                 .arrestedRobberCount(3)
                 .totalArrestCount(5)
                 .durationSeconds(300)
+                .areaType(AreaType.CIRCLE)
                 .playgroundCenter(center)
                 .playgroundRadiusInMeters(500)
                 .build();
+    }
+
+    public static GameResult POLICE_WIN_RESULT_POLYGON(Long gameId) {
+        Polygon polygon = createPolygon(new double[][]{
+                {127.0276, 37.4979}, {127.0296, 37.4979},
+                {127.0296, 37.4999}, {127.0276, 37.4999}
+        });
+        return GameResult.builder()
+                .gameId(gameId)
+                .winnerTeam(Team.POLICE)
+                .endReason(GameEndReason.ALL_ARRESTED)
+                .totalPoliceCount(2)
+                .totalRobberCount(3)
+                .arrestedRobberCount(3)
+                .totalArrestCount(5)
+                .durationSeconds(300)
+                .areaType(AreaType.POLYGON)
+                .playgroundPolygon(polygon)
+                .build();
+    }
+
+    private static Polygon createPolygon(double[][] coords) {
+        Coordinate[] coordinates = new Coordinate[coords.length + 1];
+        for (int i = 0; i < coords.length; i++) {
+            coordinates[i] = new Coordinate(coords[i][0], coords[i][1]);
+        }
+        coordinates[coords.length] = coordinates[0];
+        LinearRing ring = GEOMETRY_FACTORY.createLinearRing(coordinates);
+        return GEOMETRY_FACTORY.createPolygon(ring);
     }
 }

--- a/src/test/java/com/team/cops_and_robbers/game/participant/presentation/GameParticipantControllerTest.java
+++ b/src/test/java/com/team/cops_and_robbers/game/participant/presentation/GameParticipantControllerTest.java
@@ -474,6 +474,67 @@ class GameParticipantControllerTest extends ControllerTest {
             assertThat(game.isInProgress()).isTrue();
         }
 
+        @Nested
+        @DisplayName("폴리곤 영역 게임에서의 인게임 퇴장")
+        class WithPolygonArea {
+
+            private Game polygonGame;
+
+            @BeforeEach
+            void setUp() {
+                polygonGame = gameRepository.save(GameFixture.IN_PROGRESS_GAME());
+                gameAreaRepository.save(GameAreaFixture.POLYGON_GAME_AREA(polygonGame));
+            }
+
+            @Test
+            void 폴리곤_영역에서_마지막_경찰이_퇴장하면_게임이_종료된다() {
+                // given
+                User police = givenUser("polygonPolice");
+                String policeToken = givenAccessToken(police);
+                givenPolice(polygonGame, police);
+
+                User robber = givenUser("polygonRobber");
+                givenRobber(polygonGame, robber);
+
+                // when
+                ExtractableResponse<Response> response = authenticated(policeToken)
+                        .pathParam(GAME_ID_PARAM, polygonGame.getId())
+                        .when()
+                        .delete(LEAVE_URL)
+                        .then()
+                        .extract();
+
+                // then
+                assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+                Game game = gameRepository.findById(polygonGame.getId()).orElseThrow();
+                assertThat(game.isInProgress()).isFalse();
+            }
+
+            @Test
+            void 폴리곤_영역에서_마지막_ALIVE_도둑이_퇴장하면_게임이_종료된다() {
+                // given
+                User police = givenUser("polygonPolice");
+                givenPolice(polygonGame, police);
+
+                User aliveRobber = givenUser("polygonAliveRobber");
+                String aliveRobberToken = givenAccessToken(aliveRobber);
+                givenRobber(polygonGame, aliveRobber);
+
+                // when
+                ExtractableResponse<Response> response = authenticated(aliveRobberToken)
+                        .pathParam(GAME_ID_PARAM, polygonGame.getId())
+                        .when()
+                        .delete(LEAVE_URL)
+                        .then()
+                        .extract();
+
+                // then
+                assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+                Game game = gameRepository.findById(polygonGame.getId()).orElseThrow();
+                assertThat(game.isInProgress()).isFalse();
+            }
+        }
+
         @Test
         void 방장이_인게임에서_퇴장하면_다음_참가자에게_방장이_위임된다() {
             // given

--- a/src/test/java/com/team/cops_and_robbers/history/application/GameResultServiceTest.java
+++ b/src/test/java/com/team/cops_and_robbers/history/application/GameResultServiceTest.java
@@ -2,9 +2,15 @@ package com.team.cops_and_robbers.history.application;
 
 import com.team.cops_and_robbers.common.ServiceUnitTest;
 import com.team.cops_and_robbers.common.exception.ApplicationException;
+import com.team.cops_and_robbers.game.area.domain.AreaType;
+import com.team.cops_and_robbers.game.area.domain.GameArea;
+import com.team.cops_and_robbers.game.game.domain.Game;
+import com.team.cops_and_robbers.game.participant.domain.ParticipantStatus;
+import com.team.cops_and_robbers.game.participant.domain.Team;
 import com.team.cops_and_robbers.game.participant.exception.GameParticipantException;
 import com.team.cops_and_robbers.history.application.dto.command.GameResultCommand;
 import com.team.cops_and_robbers.history.application.dto.result.GameResultResult;
+import com.team.cops_and_robbers.history.domain.GameEndReason;
 import com.team.cops_and_robbers.history.domain.GameResult;
 import com.team.cops_and_robbers.history.exception.GameResultException;
 import org.junit.jupiter.api.DisplayName;
@@ -14,10 +20,16 @@ import org.mockito.InjectMocks;
 
 import java.util.Optional;
 
+import static com.team.cops_and_robbers.common.fixture.GameAreaFixture.CIRCLE_GAME_AREA;
+import static com.team.cops_and_robbers.common.fixture.GameAreaFixture.POLYGON_GAME_AREA;
+import static com.team.cops_and_robbers.common.fixture.GameFixture.IN_PROGRESS_GAME;
 import static com.team.cops_and_robbers.common.fixture.GameResultFixture.POLICE_WIN_RESULT;
+import static com.team.cops_and_robbers.common.fixture.GameResultFixture.POLICE_WIN_RESULT_POLYGON;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
 
 class GameResultServiceTest extends ServiceUnitTest {
 
@@ -29,13 +41,87 @@ class GameResultServiceTest extends ServiceUnitTest {
     private static final Long TEST_GAME_RESULT_ID = 1L;
 
     @Nested
+    @DisplayName("게임 결과 기록")
+    class RecordGameResult {
+
+        private static final Long TEST_GAME_ID = 1L;
+
+        @Test
+        void CIRCLE_영역_게임이_종료되면_circle_필드가_채워진_결과가_저장된다() {
+            // given
+            Game game = IN_PROGRESS_GAME();
+            setId(game, TEST_GAME_ID);
+            GameArea circleArea = CIRCLE_GAME_AREA(game);
+
+            given(gameAreaRepository.getByGameId(TEST_GAME_ID)).willReturn(circleArea);
+            given(gameParticipantRepository.countByGameIdAndTeam(TEST_GAME_ID, Team.POLICE)).willReturn(2);
+            given(gameParticipantRepository.countByGameIdAndTeam(TEST_GAME_ID, Team.ROBBER)).willReturn(3);
+            given(gameParticipantRepository.countByGameIdAndRobberStatus(TEST_GAME_ID, ParticipantStatus.JAILED)).willReturn(3);
+            given(gameResultRepository.save(any(GameResult.class))).willAnswer(inv -> inv.getArgument(0));
+
+            // when
+            GameResult result = gameResultService.recordGameResult(game, Team.POLICE, GameEndReason.ALL_ARRESTED);
+
+            // then
+            assertThat(result.getAreaType()).isEqualTo(AreaType.CIRCLE);
+            assertThat(result.getPlaygroundCenter()).isNotNull();
+            assertThat(result.getPlaygroundRadiusInMeters()).isNotNull();
+            assertThat(result.getPlaygroundPolygon()).isNull();
+            then(gameResultRepository).should().save(any(GameResult.class));
+        }
+
+        @Test
+        void POLYGON_영역_게임이_종료되면_polygon_필드가_채워진_결과가_저장된다() {
+            // given
+            Game game = IN_PROGRESS_GAME();
+            setId(game, TEST_GAME_ID);
+            GameArea polygonArea = POLYGON_GAME_AREA(game);
+
+            given(gameAreaRepository.getByGameId(TEST_GAME_ID)).willReturn(polygonArea);
+            given(gameParticipantRepository.countByGameIdAndTeam(TEST_GAME_ID, Team.POLICE)).willReturn(2);
+            given(gameParticipantRepository.countByGameIdAndTeam(TEST_GAME_ID, Team.ROBBER)).willReturn(3);
+            given(gameParticipantRepository.countByGameIdAndRobberStatus(TEST_GAME_ID, ParticipantStatus.JAILED)).willReturn(3);
+            given(gameResultRepository.save(any(GameResult.class))).willAnswer(inv -> inv.getArgument(0));
+
+            // when
+            GameResult result = gameResultService.recordGameResult(game, Team.POLICE, GameEndReason.ALL_ARRESTED);
+
+            // then
+            assertThat(result.getAreaType()).isEqualTo(AreaType.POLYGON);
+            assertThat(result.getPlaygroundPolygon()).isNotNull();
+            assertThat(result.getPlaygroundCenter()).isNull();
+            assertThat(result.getPlaygroundRadiusInMeters()).isNull();
+            then(gameResultRepository).should().save(any(GameResult.class));
+        }
+    }
+
+    @Nested
     @DisplayName("게임 결과 조회")
     class GetGameResult {
 
         @Test
-        void 게임_결과_조회에_성공한다() {
+        void CIRCLE_영역_게임_결과_조회에_성공한다() {
             // given
             GameResult gameResult = POLICE_WIN_RESULT(TEST_GAME_ID);
+            setId(gameResult, TEST_GAME_RESULT_ID);
+
+            given(gameResultRepository.findById(TEST_GAME_RESULT_ID)).willReturn(Optional.of(gameResult));
+
+            // when
+            GameResultResult result = gameResultService.getGameResult(GameResultCommand.of(TEST_USER_ID, TEST_GAME_RESULT_ID));
+
+            // then
+            assertThat(result.winnerTeam()).isEqualTo(gameResult.getWinnerTeam());
+            assertThat(result.durationSeconds()).isEqualTo(gameResult.getDurationSeconds());
+            assertThat(result.totalArrestCount()).isEqualTo(gameResult.getTotalArrestCount());
+            assertThat(result.remainingRobberCount())
+                    .isEqualTo(gameResult.getTotalRobberCount() - gameResult.getArrestedRobberCount());
+        }
+
+        @Test
+        void POLYGON_영역_게임_결과_조회에_성공한다() {
+            // given
+            GameResult gameResult = POLICE_WIN_RESULT_POLYGON(TEST_GAME_ID);
             setId(gameResult, TEST_GAME_RESULT_ID);
 
             given(gameResultRepository.findById(TEST_GAME_RESULT_ID)).willReturn(Optional.of(gameResult));

--- a/src/test/java/com/team/cops_and_robbers/play/system/presentation/SystemControllerTest.java
+++ b/src/test/java/com/team/cops_and_robbers/play/system/presentation/SystemControllerTest.java
@@ -272,6 +272,100 @@ class SystemControllerTest extends ControllerTest {
     }
 
     @Nested
+    @DisplayName("폴리곤 영역 게임에서의 체포/탈옥 API")
+    class WithPolygonGameArea {
+
+        private User polygonPolice;
+        private User polygonRobber;
+        private Game polygonGame;
+        private GameParticipant polygonPoliceParticipant;
+        private GameParticipant polygonRobberParticipant;
+        private String polygonPoliceToken;
+        private String polygonRobberToken;
+
+        @BeforeEach
+        void setUp() {
+            polygonPolice = givenUser("polygonPolice");
+            polygonRobber = givenUser("polygonRobber");
+            polygonPoliceToken = givenAccessToken(polygonPolice);
+            polygonRobberToken = givenAccessToken(polygonRobber);
+
+            polygonGame = gameRepository.save(GameFixture.IN_PROGRESS_GAME());
+            gameAreaRepository.save(GameAreaFixture.POLYGON_GAME_AREA(polygonGame));
+            polygonPoliceParticipant = givenPolice(polygonGame, polygonPolice);
+            polygonRobberParticipant = givenRobber(polygonGame, polygonRobber);
+        }
+
+        @Test
+        void 폴리곤_영역에서_도둑_체포_성공() {
+            // given
+            User secondRobber = givenUser("polygonRobber2");
+            givenRobber(polygonGame, secondRobber);
+            ArrestRequest request = new ArrestRequest(polygonRobberParticipant.getId());
+
+            // when
+            ExtractableResponse<Response> response = authenticated(polygonPoliceToken)
+                    .body(request)
+                    .pathParam(GAME_ID_PARAM, polygonGame.getId())
+                    .when()
+                    .post(ARREST_URL)
+                    .then()
+                    .extract();
+
+            // then
+            ArrestResponse result = response.as(ArrestResponse.class);
+            assertSoftly(softly -> {
+                softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+                softly.assertThat(result.robberNickname()).isEqualTo(polygonRobber.getNickname());
+                softly.assertThat(result.remainingThieves()).isEqualTo(1);
+            });
+        }
+
+        @Test
+        void 폴리곤_영역에서_마지막_도둑이_체포되면_게임이_종료된다() {
+            // given
+            ArrestRequest request = new ArrestRequest(polygonRobberParticipant.getId());
+
+            // when
+            ExtractableResponse<Response> response = authenticated(polygonPoliceToken)
+                    .body(request)
+                    .pathParam(GAME_ID_PARAM, polygonGame.getId())
+                    .when()
+                    .post(ARREST_URL)
+                    .then()
+                    .extract();
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+                Game endedGame = gameRepository.findById(polygonGame.getId()).orElseThrow();
+                softly.assertThat(endedGame.isInProgress()).isFalse();
+                softly.assertThat(gameResultRepository.existsById(1L)).isTrue();
+            });
+        }
+
+        @Test
+        void 폴리곤_영역에서_도둑_탈옥_성공() {
+            // given
+            polygonRobberParticipant.updateStatus(ParticipantStatus.JAILED);
+            gameParticipantRepository.save(polygonRobberParticipant);
+
+            // when
+            ExtractableResponse<Response> response = authenticated(polygonRobberToken)
+                    .pathParam(GAME_ID_PARAM, polygonGame.getId())
+                    .when()
+                    .post(ESCAPE_URL)
+                    .then()
+                    .extract();
+
+            // then
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+            GameParticipant escapedRobber = gameParticipantRepository.findById(polygonRobberParticipant.getId()).orElseThrow();
+            assertThat(escapedRobber.isJailed()).isFalse();
+        }
+    }
+
+    @Nested
     @DisplayName("도둑 탈옥 API")
     class EscapeFromPrison {
 


### PR DESCRIPTION
## 📎 Issue 번호
<!-- PR과 연관된 이슈의 번호를 작성해주세요.
PR 머지 시 close 되어야 하는 이슈의 경우 이슈 번호 앞에 `closed` 키워드를 붙여주세요.  
ex) `closed #2` -->
- closed #127 

## ✨ 작업 내용
<!-- 핵심적으로 변경된 사항들을 간략하게 서술해주세요. -> 예시: S3 업로드 기능 추가 -->                                                                                                 
- `GameResult` 엔티티에 폴리곤 영역 스냅샷 지원 추가 (`areaType`, `playgroundPolygon`)       
  -  자연스럽게 폴리곤 영역 게임에서 체포/나가기로 게임 종료 시 발생하던 500 오류도 수정됨                                                                              
- 폴리곤 게임 결과 관련 테스트 케이스 추가

## 🐰 원인
  `GameResultService.recordGameResult()`에서 `gameArea.getPlaygroundCenter()`,
  `getPlaygroundRadiusInMeters()`를 타입 구분 없이 호출 → 폴리곤 타입에서 null → NPE

## 🎯 리뷰 포인트
<!-- 리뷰시 중점적으로 봐주었으면 좋을 부분을 적어주세요.  
없다면 적지 않아도 됩니다. -->  
폴리곤 관련 테스트를 e2e 테스트까지 포함하여 전반적으로 추가하였습니다.

## ✅ 테스트
- [x] 수동 테스트 완료
- [x] 테스트 코드 완료
