### PR TITLE
fix: 어드민 로그인 시 미가입 유저 404 응답 분리

### DIFF
--- a/src/main/java/com/team/cops_and_robbers/auth/application/AuthService.java
+++ b/src/main/java/com/team/cops_and_robbers/auth/application/AuthService.java
@@ -173,8 +173,11 @@ public class AuthService {
         String socialId = getSocialId(command.socialType(), command.idToken());
 
         User user = userRepository.findBySocialIdAndSocialType(socialId, command.socialType())
-                .filter(User::isAdmin)
-                .orElseThrow(() -> new ApplicationException(AuthException.FORBIDDEN_ADMIN_ONLY));
+                .orElseThrow(() -> new ApplicationException(AuthException.ADMIN_USER_NOT_FOUND));
+
+        if (!user.isAdmin()) {
+            throw new ApplicationException(AuthException.FORBIDDEN_ADMIN_ONLY);
+        }
 
         Tokens tokens = issueTokens(user);
         return AdminLoginResult.of(user, tokens);

--- a/src/main/java/com/team/cops_and_robbers/auth/exception/AuthException.java
+++ b/src/main/java/com/team/cops_and_robbers/auth/exception/AuthException.java
@@ -16,6 +16,7 @@ public enum AuthException implements ExceptionCode {
     UNAUTHENTICATED_REQUEST(HttpStatus.UNAUTHORIZED, "인증되지 않은 요청", "로그인이 필요합니다."),
     UNSUPPORTED_SOCIAL_TYPE(HttpStatus.BAD_REQUEST, "지원하지 않는 로그인 방식", "지원하지 않는 소셜 로그인 방식입니다."),
     FORBIDDEN_ADMIN_ONLY(HttpStatus.FORBIDDEN, "권한 없음", "관리자 권한이 필요합니다."),
+    ADMIN_USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자 없음", "가입되지 않은 사용자입니다. 먼저 앱에서 회원가입 후 이용해주세요."),
     NICKNAME_GENERATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "회원가입 실패", "랜덤 닉네임 생성에 실패했습니다. 잠시 후 다시 시도해주세요."),
     EXPIRED_FIREBASE_TOKEN(HttpStatus.UNAUTHORIZED, "Firebase 인증 만료", "Firebase 토큰이 만료되었습니다. 다시 인증해주세요."),
     INVALID_FIREBASE_TOKEN(HttpStatus.UNAUTHORIZED, "Firebase 인증 실패", "유효하지 않은 Firebase 토큰입니다."),

--- a/src/test/java/com/team/cops_and_robbers/auth/presentation/AuthControllerTest.java
+++ b/src/test/java/com/team/cops_and_robbers/auth/presentation/AuthControllerTest.java
@@ -258,6 +258,31 @@ class AuthControllerTest extends ControllerTest {
         }
 
         @Test
+        void 미가입_유저라면_404_NOT_FOUND를_응답해야_한다() {
+            // given
+            doReturn("unknown_social_id")
+                    .when(googleLoginStrategy)
+                    .validateAndGetSocialId(anyString());
+
+            AdminLoginRequest request = new AdminLoginRequest(SocialType.GOOGLE, "valid_token");
+
+            // when
+            ExtractableResponse<Response> extract = unauthenticated()
+                    .body(request)
+                    .when()
+                    .post("/api/auth/admin/login")
+                    .then()
+                    .extract();
+
+            // then
+            ErrorResponse response = extract.as(ErrorResponse.class);
+            assertSoftly(softly -> {
+                softly.assertThat(extract.statusCode()).isEqualTo(404);
+                softly.assertThat(response.title()).isEqualTo(AuthException.ADMIN_USER_NOT_FOUND.getTitle());
+            });
+        }
+
+        @Test
         void 필수_파라미터인_idToken이_누락되면_400_BAD_REQUEST를_응답해야_한다() {
             // given
             AdminLoginRequest request = new AdminLoginRequest(SocialType.GOOGLE, null);


### PR DESCRIPTION
## ✨ 작업 내용
<!-- 핵심적으로 변경된 사항들을 간략하게 서술해주세요. -> 예시: S3 업로드 기능 추가 -->
- 어드민 로그인 시 미가입 유저와 권한 없는 유저의 에러 응답을 분리
   - 미가입 유저 -> 404
   - 일반 유저 -> 403

## ✅ 테스트
- [X] 수동 테스트 완료
- [X] 테스트 코드 완료
