### PR TITLE
feat: 어드민 지난 게임 기록 조회 API 추가

### DIFF
--- a/src/main/java/com/team/cops_and_robbers/admin/application/AdminGameHistoryService.java
+++ b/src/main/java/com/team/cops_and_robbers/admin/application/AdminGameHistoryService.java
@@ -1,0 +1,49 @@
+package com.team.cops_and_robbers.admin.application;
+
+import com.team.cops_and_robbers.admin.application.dto.command.game.AdminGameHistoryListCommand;
+import com.team.cops_and_robbers.admin.application.dto.result.game.AdminGameHistoryPageResult;
+import com.team.cops_and_robbers.admin.application.dto.result.game.AdminGameHistoryParticipantResult;
+import com.team.cops_and_robbers.admin.application.dto.result.game.AdminGameHistoryResult;
+import com.team.cops_and_robbers.history.domain.GameResult;
+import com.team.cops_and_robbers.history.repository.GameResultParticipantRepository;
+import com.team.cops_and_robbers.history.repository.GameResultRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminGameHistoryService {
+
+    private final GameResultRepository gameResultRepository;
+    private final GameResultParticipantRepository gameResultParticipantRepository;
+
+    public AdminGameHistoryPageResult getGameHistoryList(AdminGameHistoryListCommand command) {
+        Page<GameResult> resultPage = gameResultRepository.findAllForAdmin(
+                command.endReason(), command.toPageable());
+        Page<AdminGameHistoryResult> historyPage = resultPage.map(AdminGameHistoryResult::from);
+        return AdminGameHistoryPageResult.from(historyPage);
+    }
+
+    public Map<AdminGameHistoryResult, List<AdminGameHistoryParticipantResult>> getHistoryParticipantsByGame(
+            List<AdminGameHistoryResult> histories) {
+        List<Long> gameResultIds = histories.stream().map(AdminGameHistoryResult::id).toList();
+        Map<Long, List<AdminGameHistoryParticipantResult>> participantsByResultId =
+                gameResultParticipantRepository.findByGameResultIdIn(gameResultIds)
+                        .stream()
+                        .collect(Collectors.groupingBy(
+                                grp -> grp.getGameResult().getId(),
+                                Collectors.mapping(AdminGameHistoryParticipantResult::from, Collectors.toList())
+                        ));
+        return histories.stream().collect(Collectors.toMap(
+                history -> history,
+                history -> participantsByResultId.getOrDefault(history.id(), List.of())
+        ));
+    }
+}

--- a/src/main/java/com/team/cops_and_robbers/admin/application/dto/command/game/AdminGameHistoryListCommand.java
+++ b/src/main/java/com/team/cops_and_robbers/admin/application/dto/command/game/AdminGameHistoryListCommand.java
@@ -1,0 +1,19 @@
+package com.team.cops_and_robbers.admin.application.dto.command.game;
+
+import com.team.cops_and_robbers.admin.application.dto.SortDirection;
+import com.team.cops_and_robbers.history.domain.GameEndReason;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+public record AdminGameHistoryListCommand(
+        int page,
+        int size,
+        GameEndReason endReason,
+        SortDirection sortDirection
+) {
+
+    public Pageable toPageable() {
+        return PageRequest.of(page, size, Sort.by(sortDirection.toSpringDirection(), "createdAt"));
+    }
+}

--- a/src/main/java/com/team/cops_and_robbers/admin/application/dto/result/game/AdminGameHistoryPageResult.java
+++ b/src/main/java/com/team/cops_and_robbers/admin/application/dto/result/game/AdminGameHistoryPageResult.java
@@ -1,0 +1,23 @@
+package com.team.cops_and_robbers.admin.application.dto.result.game;
+
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+public record AdminGameHistoryPageResult(
+        List<AdminGameHistoryResult> content,
+        Long totalElements,
+        Integer totalPages,
+        Integer page,
+        Integer size
+) {
+    public static AdminGameHistoryPageResult from(Page<AdminGameHistoryResult> historyPage) {
+        return new AdminGameHistoryPageResult(
+                historyPage.getContent(),
+                historyPage.getTotalElements(),
+                historyPage.getTotalPages(),
+                historyPage.getNumber(),
+                historyPage.getSize()
+        );
+    }
+}

--- a/src/main/java/com/team/cops_and_robbers/admin/application/dto/result/game/AdminGameHistoryParticipantResult.java
+++ b/src/main/java/com/team/cops_and_robbers/admin/application/dto/result/game/AdminGameHistoryParticipantResult.java
@@ -1,0 +1,22 @@
+package com.team.cops_and_robbers.admin.application.dto.result.game;
+
+import com.team.cops_and_robbers.game.participant.domain.ParticipantStatus;
+import com.team.cops_and_robbers.game.participant.domain.Team;
+import com.team.cops_and_robbers.history.domain.GameResultParticipant;
+
+public record AdminGameHistoryParticipantResult(
+        Long userId,
+        String nickname,
+        Team team,
+        ParticipantStatus status
+) {
+
+    public static AdminGameHistoryParticipantResult from(GameResultParticipant participant) {
+        return new AdminGameHistoryParticipantResult(
+                participant.getUserId(),
+                participant.getNickname(),
+                participant.getTeam(),
+                participant.getStatus()
+        );
+    }
+}

--- a/src/main/java/com/team/cops_and_robbers/admin/application/dto/result/game/AdminGameHistoryResult.java
+++ b/src/main/java/com/team/cops_and_robbers/admin/application/dto/result/game/AdminGameHistoryResult.java
@@ -1,0 +1,38 @@
+package com.team.cops_and_robbers.admin.application.dto.result.game;
+
+import com.team.cops_and_robbers.common.util.TimestampUtil;
+import com.team.cops_and_robbers.game.area.domain.AreaType;
+import com.team.cops_and_robbers.game.participant.domain.Team;
+import com.team.cops_and_robbers.history.domain.GameEndReason;
+import com.team.cops_and_robbers.history.domain.GameResult;
+
+public record AdminGameHistoryResult(
+        Long id,
+        Long gameId,
+        Team winnerTeam,
+        GameEndReason endReason,
+        Integer totalPoliceCount,
+        Integer totalRobberCount,
+        Integer arrestedRobberCount,
+        Integer totalArrestCount,
+        Integer durationSeconds,
+        AreaType areaType,
+        String createdAt
+) {
+
+    public static AdminGameHistoryResult from(GameResult gameResult) {
+        return new AdminGameHistoryResult(
+                gameResult.getId(),
+                gameResult.getGameId(),
+                gameResult.getWinnerTeam(),
+                gameResult.getEndReason(),
+                gameResult.getTotalPoliceCount(),
+                gameResult.getTotalRobberCount(),
+                gameResult.getArrestedRobberCount(),
+                gameResult.getTotalArrestCount(),
+                gameResult.getDurationSeconds(),
+                gameResult.getAreaType(),
+                TimestampUtil.toIsoString(gameResult.getCreatedAt())
+        );
+    }
+}

--- a/src/main/java/com/team/cops_and_robbers/admin/presentation/AdminGameResolver.java
+++ b/src/main/java/com/team/cops_and_robbers/admin/presentation/AdminGameResolver.java
@@ -1,14 +1,20 @@
 package com.team.cops_and_robbers.admin.presentation;
 
+import com.team.cops_and_robbers.admin.application.AdminGameHistoryService;
 import com.team.cops_and_robbers.admin.application.AdminGameService;
 import com.team.cops_and_robbers.admin.application.dto.SortDirection;
+import com.team.cops_and_robbers.admin.application.dto.command.game.AdminGameHistoryListCommand;
 import com.team.cops_and_robbers.admin.application.dto.command.game.AdminGameListCommand;
 import com.team.cops_and_robbers.admin.application.dto.result.game.AdminGameAreaResult;
 import com.team.cops_and_robbers.admin.application.dto.result.game.AdminGameDetailResult;
+import com.team.cops_and_robbers.admin.application.dto.result.game.AdminGameHistoryPageResult;
+import com.team.cops_and_robbers.admin.application.dto.result.game.AdminGameHistoryParticipantResult;
+import com.team.cops_and_robbers.admin.application.dto.result.game.AdminGameHistoryResult;
 import com.team.cops_and_robbers.admin.application.dto.result.game.AdminGamePageResult;
 import com.team.cops_and_robbers.admin.application.dto.result.game.AdminGameResult;
 import com.team.cops_and_robbers.admin.application.dto.result.game.AdminParticipantResult;
 import com.team.cops_and_robbers.game.game.domain.GameStatus;
+import com.team.cops_and_robbers.history.domain.GameEndReason;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
@@ -27,6 +33,7 @@ import java.util.Map;
 public class AdminGameResolver {
 
     private final AdminGameService adminGameService;
+    private final AdminGameHistoryService adminGameHistoryService;
 
     @QueryMapping
     public AdminGamePageResult adminGames(
@@ -61,5 +68,23 @@ public class AdminGameResolver {
     public Map<AdminGameResult, AdminGameAreaResult> area(
             List<AdminGameResult> games) {
         return adminGameService.getAreasByGame(games);
+    }
+
+    @QueryMapping
+    public AdminGameHistoryPageResult adminGameHistories(
+            @Argument @Min(0) int page,
+            @Argument @Min(1) @Max(100) int size,
+            @Argument GameEndReason endReason,
+            @Argument SortDirection sortDirection
+    ) {
+        AdminGameHistoryListCommand command = new AdminGameHistoryListCommand(
+                page, size, endReason, sortDirection != null ? sortDirection : SortDirection.DESC);
+        return adminGameHistoryService.getGameHistoryList(command);
+    }
+
+    @BatchMapping(typeName = "AdminGameHistory", field = "participants")
+    public Map<AdminGameHistoryResult, List<AdminGameHistoryParticipantResult>> historyParticipants(
+            List<AdminGameHistoryResult> histories) {
+        return adminGameHistoryService.getHistoryParticipantsByGame(histories);
     }
 }

--- a/src/main/java/com/team/cops_and_robbers/common/config/WebConfig.java
+++ b/src/main/java/com/team/cops_and_robbers/common/config/WebConfig.java
@@ -79,9 +79,15 @@ public class WebConfig implements WebMvcConfigurer {
                 .allowCredentials(true);
 
         registry.addMapping("/api/community-posts/**")
-                .allowedOrigins("*")
+                .allowedOrigins(
+                        "http://localhost:3000",
+                        "https://copsandrobbers.app",
+                        "https://admin.copsandrobbers.app",
+                        "https://copsnro66ers.site"
+                )
                 .allowedMethods("GET", "OPTIONS")
-                .allowedHeaders("*");
+                .allowedHeaders("*")
+                .allowCredentials(true);
     }
 
     @Override

--- a/src/main/java/com/team/cops_and_robbers/common/config/WebConfig.java
+++ b/src/main/java/com/team/cops_and_robbers/common/config/WebConfig.java
@@ -28,6 +28,8 @@ public class WebConfig implements WebMvcConfigurer {
                 .excludePathPatterns(
                         "/api/auth/**",
                         "/api/user/check-nickname",
+                        "/api/community-posts",
+                        "/api/community-posts/{postId}",
                         "/actuator/health"
                 );
 
@@ -75,6 +77,11 @@ public class WebConfig implements WebMvcConfigurer {
                 .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
                 .allowedHeaders("*")
                 .allowCredentials(true);
+
+        registry.addMapping("/api/community-posts/**")
+                .allowedOrigins("*")
+                .allowedMethods("GET", "OPTIONS")
+                .allowedHeaders("*");
     }
 
     @Override

--- a/src/main/java/com/team/cops_and_robbers/common/swagger/SwaggerConfig.java
+++ b/src/main/java/com/team/cops_and_robbers/common/swagger/SwaggerConfig.java
@@ -30,8 +30,14 @@ public class SwaggerConfig {
 
         Info info = new Info()
                 .title("👮 경찰과 도둑 API 🥷")
-                .version("2.15.0")
+                .version("2.16.0")
                 .description("""
+                        ## v2.16.0 업데이트 내역
+
+                        ### 🛠 변경
+                        - GET /api/community-posts, GET /api/community-posts/{postId} 비로그인 조회 허용
+                          - 웹뷰 지원을 위해 @AuthUser 제거
+
                         ## v2.15.0 업데이트 내역
 
                         ### ✨ 신규

--- a/src/main/java/com/team/cops_and_robbers/community/presentation/CommunityPostController.java
+++ b/src/main/java/com/team/cops_and_robbers/community/presentation/CommunityPostController.java
@@ -46,7 +46,6 @@ public class CommunityPostController implements CommunityPostControllerDocs {
 
     @GetMapping
     public ResponseEntity<CommunityPostListResponse> getPostList(
-            @AuthUser LoginUser loginUser,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size
     ) {
@@ -58,7 +57,6 @@ public class CommunityPostController implements CommunityPostControllerDocs {
 
     @GetMapping("/{postId}")
     public ResponseEntity<CommunityPostResponse> getPost(
-            @AuthUser LoginUser loginUser,
             @PathVariable Long postId
     ) {
         CommunityPostResult result = communityPostService.getPost(postId);

--- a/src/main/java/com/team/cops_and_robbers/community/presentation/CommunityPostControllerDocs.java
+++ b/src/main/java/com/team/cops_and_robbers/community/presentation/CommunityPostControllerDocs.java
@@ -37,7 +37,6 @@ public interface CommunityPostControllerDocs {
             @ApiResponse(responseCode = "200", description = "조회 성공")
     })
     ResponseEntity<CommunityPostListResponse> getPostList(
-            @Parameter(hidden = true) LoginUser loginUser,
             @Parameter(description = "페이지 번호 (0부터 시작)", example = "0") @RequestParam(defaultValue = "0") int page,
             @Parameter(description = "페이지 크기 (1부터~)", example = "10") @RequestParam(defaultValue = "10") int size
     );
@@ -48,7 +47,6 @@ public interface CommunityPostControllerDocs {
             @ApiResponse(responseCode = "200", description = "조회 성공")
     })
     ResponseEntity<CommunityPostResponse> getPost(
-            @Parameter(hidden = true) LoginUser loginUser,
             @PathVariable Long postId
     );
 

--- a/src/main/java/com/team/cops_and_robbers/history/application/GameResultService.java
+++ b/src/main/java/com/team/cops_and_robbers/history/application/GameResultService.java
@@ -11,18 +11,23 @@ import com.team.cops_and_robbers.history.application.dto.command.GameResultComma
 import com.team.cops_and_robbers.history.application.dto.result.GameResultResult;
 import com.team.cops_and_robbers.history.domain.GameEndReason;
 import com.team.cops_and_robbers.history.domain.GameResult;
+import com.team.cops_and_robbers.history.domain.GameResultParticipant;
 import com.team.cops_and_robbers.history.exception.GameResultException;
+import com.team.cops_and_robbers.history.repository.GameResultParticipantRepository;
 import com.team.cops_and_robbers.history.repository.GameResultRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class GameResultService {
 
     private final GameResultRepository gameResultRepository;
+    private final GameResultParticipantRepository gameResultParticipantRepository;
     private final GameAreaRepository gameAreaRepository;
     private final GameParticipantRepository gameParticipantRepository;
 
@@ -53,7 +58,19 @@ public class GameResultService {
                 gameArea
         );
 
-        return gameResultRepository.save(result);
+        GameResult savedResult = gameResultRepository.save(result);
+        saveParticipantSnapshots(savedResult, game.getId());
+
+        return savedResult;
+    }
+
+    private void saveParticipantSnapshots(GameResult gameResult, Long gameId) {
+        List<GameResultParticipant> snapshots =
+                gameParticipantRepository.findAllByGameIdWithUser(gameId)
+                        .stream()
+                        .map(gp -> GameResultParticipant.createSnapshot(gameResult, gp))
+                        .toList();
+        gameResultParticipantRepository.saveAll(snapshots);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/team/cops_and_robbers/history/domain/GameResultParticipant.java
+++ b/src/main/java/com/team/cops_and_robbers/history/domain/GameResultParticipant.java
@@ -1,0 +1,66 @@
+package com.team.cops_and_robbers.history.domain;
+
+import com.team.cops_and_robbers.common.BaseTimeEntity;
+import com.team.cops_and_robbers.game.participant.domain.GameParticipant;
+import com.team.cops_and_robbers.game.participant.domain.ParticipantStatus;
+import com.team.cops_and_robbers.game.participant.domain.Team;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "game_result_participants")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class GameResultParticipant extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "game_result_id", nullable = false)
+    private GameResult gameResult;
+
+    @Column(nullable = false)
+    private Long userId;
+
+    @Column(nullable = false, length = 20)
+    private String nickname;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Team team;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ParticipantStatus status;
+
+    public static GameResultParticipant createSnapshot(
+            GameResult gameResult,
+            GameParticipant participant
+    ) {
+        return GameResultParticipant.builder()
+                .gameResult(gameResult)
+                .userId(participant.getUser().getId())
+                .nickname(participant.getUser().getNickname())
+                .team(participant.getTeam())
+                .status(participant.getStatus())
+                .build();
+    }
+}

--- a/src/main/java/com/team/cops_and_robbers/history/repository/GameResultParticipantRepository.java
+++ b/src/main/java/com/team/cops_and_robbers/history/repository/GameResultParticipantRepository.java
@@ -1,0 +1,11 @@
+package com.team.cops_and_robbers.history.repository;
+
+import com.team.cops_and_robbers.history.domain.GameResultParticipant;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface GameResultParticipantRepository extends JpaRepository<GameResultParticipant, Long> {
+
+    List<GameResultParticipant> findByGameResultIdIn(List<Long> gameResultIds);
+}

--- a/src/main/java/com/team/cops_and_robbers/history/repository/GameResultRepository.java
+++ b/src/main/java/com/team/cops_and_robbers/history/repository/GameResultRepository.java
@@ -1,9 +1,13 @@
 package com.team.cops_and_robbers.history.repository;
 
 import com.team.cops_and_robbers.game.participant.domain.Team;
+import com.team.cops_and_robbers.history.domain.GameEndReason;
 import com.team.cops_and_robbers.history.domain.GameResult;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -21,4 +25,13 @@ public interface GameResultRepository extends JpaRepository<GameResult, Long> {
     Double averageDurationSeconds();
 
     long countByWinnerTeam(Team winnerTeam);
+
+    @Query("""
+            select r from GameResult r
+            where (:endReason is null or r.endReason = :endReason)
+            """)
+    Page<GameResult> findAllForAdmin(
+            @Param("endReason") GameEndReason endReason,
+            Pageable pageable
+    );
 }

--- a/src/main/resources/db/migration/V260814_2200__add_game_result_participants.sql
+++ b/src/main/resources/db/migration/V260814_2200__add_game_result_participants.sql
@@ -1,0 +1,13 @@
+CREATE TABLE game_result_participants
+(
+    id             BIGINT AUTO_INCREMENT PRIMARY KEY,
+    game_result_id BIGINT       NOT NULL,
+    user_id        BIGINT       NOT NULL,
+    nickname       VARCHAR(20)  NOT NULL,
+    team           VARCHAR(255) NOT NULL,
+    status         VARCHAR(255) NOT NULL,
+    created_at     DATETIME(6)  NOT NULL,
+    updated_at     DATETIME(6)  NOT NULL,
+    CONSTRAINT fk_game_result_participants_game_result
+        FOREIGN KEY (game_result_id) REFERENCES game_results (id)
+);

--- a/src/main/resources/graphql/game.graphqls
+++ b/src/main/resources/graphql/game.graphqls
@@ -99,7 +99,7 @@ type AdminGameHistoryPage {
 
 type AdminGameHistory {
   id: ID!
-  gameId: Int!
+  gameId: ID!
   winnerTeam: Team!
   endReason: GameEndReason!
   totalPoliceCount: Int!

--- a/src/main/resources/graphql/game.graphqls
+++ b/src/main/resources/graphql/game.graphqls
@@ -8,6 +8,13 @@ extend type Query {
   ): AdminGamePage!
 
   adminGame(id: ID!): AdminGame!
+
+  adminGameHistories(
+    page: Int = 0
+    size: Int = 20
+    endReason: GameEndReason
+    sortDirection: SortDirection = DESC
+  ): AdminGameHistoryPage!
 }
 
 # ─── 게임 타입 ───────────────────────────────────────────────
@@ -79,4 +86,35 @@ type GameArea {
 type Coordinate {
   latitude: Float!
   longitude: Float!
+}
+
+# ─── 게임 기록 타입 ──────────────────────────────────────────
+type AdminGameHistoryPage {
+  content: [AdminGameHistory!]!
+  totalElements: Int!
+  totalPages: Int!
+  page: Int!
+  size: Int!
+}
+
+type AdminGameHistory {
+  id: ID!
+  gameId: Int!
+  winnerTeam: Team!
+  endReason: GameEndReason!
+  totalPoliceCount: Int!
+  totalRobberCount: Int!
+  arrestedRobberCount: Int!
+  totalArrestCount: Int!
+  durationSeconds: Int!
+  areaType: AreaType!
+  createdAt: String!
+  participants: [AdminGameHistoryParticipant!]!
+}
+
+type AdminGameHistoryParticipant {
+  userId: ID!
+  nickname: String!
+  team: Team!
+  status: ParticipantStatus!
 }

--- a/src/test/java/com/team/cops_and_robbers/admin/application/AdminGameHistoryServiceTest.java
+++ b/src/test/java/com/team/cops_and_robbers/admin/application/AdminGameHistoryServiceTest.java
@@ -1,0 +1,199 @@
+package com.team.cops_and_robbers.admin.application;
+
+import com.team.cops_and_robbers.admin.application.dto.SortDirection;
+import com.team.cops_and_robbers.admin.application.dto.command.game.AdminGameHistoryListCommand;
+import com.team.cops_and_robbers.admin.application.dto.result.game.AdminGameHistoryPageResult;
+import com.team.cops_and_robbers.admin.application.dto.result.game.AdminGameHistoryParticipantResult;
+import com.team.cops_and_robbers.admin.application.dto.result.game.AdminGameHistoryResult;
+import com.team.cops_and_robbers.common.ServiceUnitTest;
+import com.team.cops_and_robbers.common.fixture.GameResultFixture;
+import com.team.cops_and_robbers.common.fixture.GameResultParticipantFixture;
+import com.team.cops_and_robbers.game.participant.domain.Team;
+import com.team.cops_and_robbers.history.domain.GameEndReason;
+import com.team.cops_and_robbers.history.domain.GameResult;
+import com.team.cops_and_robbers.history.domain.GameResultParticipant;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyList;
+import static org.mockito.Mockito.isNull;
+
+class AdminGameHistoryServiceTest extends ServiceUnitTest {
+
+    private static final LocalDateTime FIXED_TIME = LocalDateTime.of(2026, 1, 1, 0, 0);
+
+    @InjectMocks
+    private AdminGameHistoryService adminGameHistoryService;
+
+    private GameResult createGameResult(Long gameId, Long id) {
+        GameResult gameResult = GameResultFixture.POLICE_WIN_RESULT(gameId);
+        setId(gameResult, id);
+        org.springframework.test.util.ReflectionTestUtils.setField(gameResult, "createdAt", FIXED_TIME);
+        return gameResult;
+    }
+
+    @Nested
+    @DisplayName("게임 히스토리 목록 조회")
+    class GetGameHistoryList {
+
+        @Test
+        void 필터_없이_히스토리_목록을_조회하면_전체_페이지를_반환한다() {
+            // given
+            AdminGameHistoryListCommand command = new AdminGameHistoryListCommand(
+                    0, 10, null, SortDirection.DESC);
+
+            GameResult result1 = createGameResult(1L, 10L);
+            GameResult result2 = createGameResult(2L, 11L);
+
+            Page<GameResult> resultPage = new PageImpl<>(
+                    List.of(result1, result2), PageRequest.of(0, 10), 2);
+            given(gameResultRepository.findAllForAdmin(isNull(), any())).willReturn(resultPage);
+
+            // when
+            AdminGameHistoryPageResult result = adminGameHistoryService.getGameHistoryList(command);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(result.totalElements()).isEqualTo(2);
+                softly.assertThat(result.content()).hasSize(2);
+            });
+        }
+
+        @Test
+        void 종료_사유_필터로_히스토리를_조회하면_해당_사유만_반환한다() {
+            // given
+            AdminGameHistoryListCommand command = new AdminGameHistoryListCommand(
+                    0, 10, GameEndReason.ALL_ARRESTED, SortDirection.DESC);
+
+            GameResult result1 = createGameResult(1L, 10L);
+
+            Page<GameResult> resultPage = new PageImpl<>(
+                    List.of(result1), PageRequest.of(0, 10), 1);
+            given(gameResultRepository.findAllForAdmin(any(GameEndReason.class), any()))
+                    .willReturn(resultPage);
+
+            // when
+            AdminGameHistoryPageResult result = adminGameHistoryService.getGameHistoryList(command);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(result.totalElements()).isEqualTo(1);
+                softly.assertThat(result.content().get(0).endReason())
+                        .isEqualTo(GameEndReason.ALL_ARRESTED);
+            });
+        }
+
+        @Test
+        void 결과가_없으면_빈_페이지를_반환한다() {
+            // given
+            AdminGameHistoryListCommand command = new AdminGameHistoryListCommand(
+                    0, 10, null, SortDirection.ASC);
+
+            Page<GameResult> emptyPage = new PageImpl<>(
+                    List.of(), PageRequest.of(0, 10), 0);
+            given(gameResultRepository.findAllForAdmin(isNull(), any())).willReturn(emptyPage);
+
+            // when
+            AdminGameHistoryPageResult result = adminGameHistoryService.getGameHistoryList(command);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(result.totalElements()).isZero();
+                softly.assertThat(result.content()).isEmpty();
+            });
+        }
+    }
+
+    @Nested
+    @DisplayName("히스토리별 참여자 배치 조회")
+    class GetHistoryParticipantsByGame {
+
+        @Test
+        void 참여자가_있는_히스토리의_참여자_목록을_반환한다() {
+            // given
+            GameResult gameResult1 = createGameResult(1L, 10L);
+            GameResult gameResult2 = createGameResult(2L, 11L);
+
+            GameResultParticipant participant =
+                    GameResultParticipantFixture.POLICE_PARTICIPANT(gameResult1, 100L, "player1");
+            setId(participant, 1000L);
+
+            AdminGameHistoryResult history1 = AdminGameHistoryResult.from(gameResult1);
+            AdminGameHistoryResult history2 = AdminGameHistoryResult.from(gameResult2);
+            List<AdminGameHistoryResult> histories = List.of(history1, history2);
+
+            given(gameResultParticipantRepository.findByGameResultIdIn(List.of(10L, 11L)))
+                    .willReturn(List.of(participant));
+
+            // when
+            Map<AdminGameHistoryResult, List<AdminGameHistoryParticipantResult>> result =
+                    adminGameHistoryService.getHistoryParticipantsByGame(histories);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(result).hasSize(2);
+                softly.assertThat(result.get(history1)).hasSize(1);
+                softly.assertThat(result.get(history1).get(0).nickname()).isEqualTo("player1");
+                softly.assertThat(result.get(history1).get(0).team()).isEqualTo(Team.POLICE);
+                softly.assertThat(result.get(history2)).isEmpty();
+            });
+        }
+
+        @Test
+        void 참여자가_없는_히스토리는_빈_리스트를_반환한다() {
+            // given
+            GameResult gameResult = createGameResult(1L, 10L);
+
+            AdminGameHistoryResult history = AdminGameHistoryResult.from(gameResult);
+            given(gameResultParticipantRepository.findByGameResultIdIn(anyList()))
+                    .willReturn(List.of());
+
+            // when
+            Map<AdminGameHistoryResult, List<AdminGameHistoryParticipantResult>> result =
+                    adminGameHistoryService.getHistoryParticipantsByGame(List.of(history));
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(result).hasSize(1);
+                softly.assertThat(result.get(history)).isEmpty();
+            });
+        }
+
+        @Test
+        void 한_히스토리에_여러_참여자가_있는_경우_모두_반환한다() {
+            // given
+            GameResult gameResult = createGameResult(1L, 10L);
+
+            GameResultParticipant participant1 =
+                    GameResultParticipantFixture.POLICE_PARTICIPANT(gameResult, 100L, "police1");
+            setId(participant1, 1000L);
+            GameResultParticipant participant2 =
+                    GameResultParticipantFixture.ROBBER_PARTICIPANT(gameResult, 101L, "robber1");
+            setId(participant2, 1001L);
+
+            AdminGameHistoryResult history = AdminGameHistoryResult.from(gameResult);
+            given(gameResultParticipantRepository.findByGameResultIdIn(List.of(10L)))
+                    .willReturn(List.of(participant1, participant2));
+
+            // when
+            Map<AdminGameHistoryResult, List<AdminGameHistoryParticipantResult>> result =
+                    adminGameHistoryService.getHistoryParticipantsByGame(List.of(history));
+
+            // then
+            assertThat(result.get(history)).hasSize(2);
+        }
+    }
+}

--- a/src/test/java/com/team/cops_and_robbers/common/ServiceUnitTest.java
+++ b/src/test/java/com/team/cops_and_robbers/common/ServiceUnitTest.java
@@ -6,6 +6,7 @@ import com.team.cops_and_robbers.community.repository.CommunityPostRepository;
 import com.team.cops_and_robbers.game.area.repository.GameAreaRepository;
 import com.team.cops_and_robbers.game.game.repository.GameRepository;
 import com.team.cops_and_robbers.game.participant.repository.GameParticipantRepository;
+import com.team.cops_and_robbers.history.repository.GameResultParticipantRepository;
 import com.team.cops_and_robbers.history.repository.GameResultRepository;
 import com.team.cops_and_robbers.notice.repository.NoticeRepository;
 import com.team.cops_and_robbers.report.repository.ReportRepository;
@@ -30,6 +31,9 @@ public abstract class ServiceUnitTest {
 
     @Mock
     protected GameResultRepository gameResultRepository;
+
+    @Mock
+    protected GameResultParticipantRepository gameResultParticipantRepository;
 
     @Mock
     protected UserRepository userRepository;

--- a/src/test/java/com/team/cops_and_robbers/common/fixture/GameResultParticipantFixture.java
+++ b/src/test/java/com/team/cops_and_robbers/common/fixture/GameResultParticipantFixture.java
@@ -1,0 +1,29 @@
+package com.team.cops_and_robbers.common.fixture;
+
+import com.team.cops_and_robbers.game.participant.domain.ParticipantStatus;
+import com.team.cops_and_robbers.game.participant.domain.Team;
+import com.team.cops_and_robbers.history.domain.GameResult;
+import com.team.cops_and_robbers.history.domain.GameResultParticipant;
+
+public class GameResultParticipantFixture {
+
+    public static GameResultParticipant POLICE_PARTICIPANT(GameResult gameResult, Long userId, String nickname) {
+        return GameResultParticipant.builder()
+                .gameResult(gameResult)
+                .userId(userId)
+                .nickname(nickname)
+                .team(Team.POLICE)
+                .status(ParticipantStatus.ALIVE)
+                .build();
+    }
+
+    public static GameResultParticipant ROBBER_PARTICIPANT(GameResult gameResult, Long userId, String nickname) {
+        return GameResultParticipant.builder()
+                .gameResult(gameResult)
+                .userId(userId)
+                .nickname(nickname)
+                .team(Team.ROBBER)
+                .status(ParticipantStatus.JAILED)
+                .build();
+    }
+}

--- a/src/test/java/com/team/cops_and_robbers/community/presentation/CommunityPostControllerTest.java
+++ b/src/test/java/com/team/cops_and_robbers/community/presentation/CommunityPostControllerTest.java
@@ -142,7 +142,7 @@ class CommunityPostControllerTest extends ControllerTest {
         }
 
         @Test
-        void 토큰_없이_요청하면_401을_응답한다() {
+        void 토큰_없이_요청해도_200을_응답한다() {
             ExtractableResponse<Response> extract = unauthenticated()
                     .when()
                     .get(POST_API_URL)
@@ -150,7 +150,7 @@ class CommunityPostControllerTest extends ControllerTest {
                     .extract();
 
             assertSoftly(softly -> {
-                softly.assertThat(extract.statusCode()).isEqualTo(401);
+                softly.assertThat(extract.statusCode()).isEqualTo(200);
             });
         }
     }
@@ -190,15 +190,17 @@ class CommunityPostControllerTest extends ControllerTest {
         }
 
         @Test
-        void 토큰_없이_요청하면_401을_응답한다() {
+        void 토큰_없이_요청해도_200을_응답한다() {
+            Long postId = communityPostRepository.save(POST(user.getId())).getId();
+
             ExtractableResponse<Response> extract = unauthenticated()
                     .when()
-                    .get(POST_API_URL + "/1")
+                    .get(POST_API_URL + "/" + postId)
                     .then()
                     .extract();
 
             assertSoftly(softly -> {
-                softly.assertThat(extract.statusCode()).isEqualTo(401);
+                softly.assertThat(extract.statusCode()).isEqualTo(200);
             });
         }
     }


### PR DESCRIPTION
## 📎 Issue 번호
- closed #148

## ✨ 작업 내용
어드민 대시보드에서 게임 히스토리(종료된 게임 결과)를 조회할 수 있는 GraphQL API를 구현했습니다.

- 게임 종료 시 참여자 스냅샷 저장 기능 추가
- 어드민 히스토리 목록 조회 API 추가 (종료 사유 필터, 정렬)
- 히스토리별 참여자 BatchMapping 조회 추가
- 커뮤니티 게시글 조회 비로그인 허용 및 CORS 전체 오픈

### 참여자 스냅샷 추가 배경

기존에는 게임 종료 시 승패 결과(`GameResult`)만 저장하고 참여자 정보는 별도로 저장하지 않았습니다.
그래서 어드민 히스토리에서 "해당 게임에 누가 참여했는지"를 보여줄 수 없었고, `GameParticipant`는 게임 삭제 시 함께 삭제되기 때문에 과거 기록을 참조할 수도 없었습니다.

이를 해결하기 위해 게임 종료 시점에 참여자 정보를 `GameResultParticipant` 테이블에 스냅샷으로 저장하도록 했습니다.
향후 마이페이지에서 유저별 게임 이력 조회 등 확장 기능에도 활용할 수 있습니다.

### 히스토리 조회 API

항목 | 설명
-- | --
목록 필터 | 종료 사유(GameEndReason)
정렬 | 생성일 기준 ASC/DESC
참여자 | BatchMapping으로 히스토리별 자동 로딩

### 패키지 구조 (신규/변경)

```
admin/
 └─ application/
     ├─ AdminGameHistoryService (신규)
     └─ dto/
         ├─ command/game/
         │   └─ AdminGameHistoryListCommand (신규)
         └─ result/game/
             ├─ AdminGameHistoryResult (신규)
             ├─ AdminGameHistoryPageResult (신규)
             └─ AdminGameHistoryParticipantResult (신규)

history/
 ├─ domain/
 │   └─ GameResultParticipant (신규)
 └─ repository/
     └─ GameResultParticipantRepository (신규)
```

### CORS 구성 현황

경로 | 허용 Origin | 허용 메서드 | Credentials
-- | -- | -- | --
`/graphql` | localhost:3000, copsnro66ers.site, admin.copsnro66ers.site, dev-api.copsnro66ers.site, copsandrobbers.app, admin.copsandrobbers.app, dev-api.copsandrobbers.app | POST, OPTIONS | O
`/api/auth/**` | (위와 동일) | POST, OPTIONS | O
`/api/notices/**` | localhost:3000, copsnro66ers.site, admin.copsnro66ers.site, dev-api.copsnro66ers.site, copsandrobbers.app, admin.copsandrobbers.app, dev-api.copsandrobbers.app | GET, POST, PUT, DELETE, OPTIONS | O
`/api/community-posts/**` | localhost:3000, copsandrobbers.app, admin.copsandrobbers.app, copsnro66ers.site | GET, OPTIONS | O


## 📝 기타
- 커뮤니티 조회 기능에서 웹뷰를 위해 로그인 없이도 조회 가능하도록 `@AuthUser`를 제거했습니다.

## ✅ 테스트
- [ ] 수동 테스트 완료
- [x] 테스트 코드 완료