### PR TITLE
feat: 어드민 지난 게임 기록에 플레이 구역 좌표 노출

### DIFF
--- a/src/main/java/com/team/cops_and_robbers/admin/application/AdminGameHistoryService.java
+++ b/src/main/java/com/team/cops_and_robbers/admin/application/AdminGameHistoryService.java
@@ -31,6 +31,10 @@ public class AdminGameHistoryService {
         return AdminGameHistoryPageResult.from(historyPage);
     }
 
+    public AdminGameHistoryResult getGameHistory(Long gameResultId) {
+        return AdminGameHistoryResult.from(gameResultRepository.getByGameResultId(gameResultId));
+    }
+
     public Map<AdminGameHistoryResult, List<AdminGameHistoryParticipantResult>> getHistoryParticipantsByGame(
             List<AdminGameHistoryResult> histories) {
         List<Long> gameResultIds = histories.stream().map(AdminGameHistoryResult::id).toList();

--- a/src/main/java/com/team/cops_and_robbers/admin/application/dto/result/game/AdminGameAreaResult.java
+++ b/src/main/java/com/team/cops_and_robbers/admin/application/dto/result/game/AdminGameAreaResult.java
@@ -57,9 +57,9 @@ public record AdminGameAreaResult(
                     gameResult.getPlaygroundCenter().getY(),
                     gameResult.getPlaygroundCenter().getX(),
                     gameResult.getPlaygroundRadiusInMeters(),
-                    null,
-                    null,
-                    null,
+                    gameResult.getJailCenter() == null ? null : gameResult.getJailCenter().getY(),
+                    gameResult.getJailCenter() == null ? null : gameResult.getJailCenter().getX(),
+                    gameResult.getJailRadiusInMeters(),
                     null,
                     null
             );
@@ -72,7 +72,7 @@ public record AdminGameAreaResult(
                     null,
                     null,
                     toCoordinatesList(gameResult.getPlaygroundPolygon()),
-                    null
+                    gameResult.getJailPolygon() == null ? null : toCoordinatesList(gameResult.getJailPolygon())
             );
         };
     }

--- a/src/main/java/com/team/cops_and_robbers/admin/application/dto/result/game/AdminGameAreaResult.java
+++ b/src/main/java/com/team/cops_and_robbers/admin/application/dto/result/game/AdminGameAreaResult.java
@@ -2,6 +2,7 @@ package com.team.cops_and_robbers.admin.application.dto.result.game;
 
 import com.team.cops_and_robbers.game.area.domain.AreaType;
 import com.team.cops_and_robbers.game.area.domain.GameArea;
+import com.team.cops_and_robbers.history.domain.GameResult;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Polygon;
 
@@ -45,6 +46,33 @@ public record AdminGameAreaResult(
                     null,
                     toCoordinatesList(gameArea.getPlaygroundPolygon()),
                     toCoordinatesList(gameArea.getJailPolygon())
+            );
+        };
+    }
+
+    public static AdminGameAreaResult from(GameResult gameResult) {
+        return switch (gameResult.getAreaType()) {
+            case CIRCLE -> new AdminGameAreaResult(
+                    AreaType.CIRCLE,
+                    gameResult.getPlaygroundCenter().getY(),
+                    gameResult.getPlaygroundCenter().getX(),
+                    gameResult.getPlaygroundRadiusInMeters(),
+                    null,
+                    null,
+                    null,
+                    null,
+                    null
+            );
+            case POLYGON -> new AdminGameAreaResult(
+                    AreaType.POLYGON,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    toCoordinatesList(gameResult.getPlaygroundPolygon()),
+                    null
             );
         };
     }

--- a/src/main/java/com/team/cops_and_robbers/admin/application/dto/result/game/AdminGameHistoryResult.java
+++ b/src/main/java/com/team/cops_and_robbers/admin/application/dto/result/game/AdminGameHistoryResult.java
@@ -17,6 +17,7 @@ public record AdminGameHistoryResult(
         Integer totalArrestCount,
         Integer durationSeconds,
         AreaType areaType,
+        AdminGameAreaResult area,
         String createdAt
 ) {
 
@@ -32,7 +33,15 @@ public record AdminGameHistoryResult(
                 gameResult.getTotalArrestCount(),
                 gameResult.getDurationSeconds(),
                 gameResult.getAreaType(),
+                toAreaResult(gameResult),
                 TimestampUtil.toIsoString(gameResult.getCreatedAt())
         );
+    }
+
+    private static AdminGameAreaResult toAreaResult(GameResult gameResult) {
+        if (gameResult.getPlaygroundCenter() == null && gameResult.getPlaygroundPolygon() == null) {
+            return null;
+        }
+        return AdminGameAreaResult.from(gameResult);
     }
 }

--- a/src/main/java/com/team/cops_and_robbers/admin/presentation/AdminGameResolver.java
+++ b/src/main/java/com/team/cops_and_robbers/admin/presentation/AdminGameResolver.java
@@ -82,6 +82,11 @@ public class AdminGameResolver {
         return adminGameHistoryService.getGameHistoryList(command);
     }
 
+    @QueryMapping
+    public AdminGameHistoryResult adminGameHistory(@Argument Long id) {
+        return adminGameHistoryService.getGameHistory(id);
+    }
+
     @BatchMapping(typeName = "AdminGameHistory", field = "participants")
     public Map<AdminGameHistoryResult, List<AdminGameHistoryParticipantResult>> historyParticipants(
             List<AdminGameHistoryResult> histories) {

--- a/src/main/java/com/team/cops_and_robbers/history/domain/GameResult.java
+++ b/src/main/java/com/team/cops_and_robbers/history/domain/GameResult.java
@@ -74,6 +74,14 @@ public class GameResult extends BaseTimeEntity {
     @Column(columnDefinition = "GEOMETRY(POLYGON, 4326)")
     private Polygon playgroundPolygon;
 
+    @Column(columnDefinition = "GEOMETRY(POINT, 4326)")
+    private Point jailCenter;
+
+    private Integer jailRadiusInMeters;
+
+    @Column(columnDefinition = "GEOMETRY(POLYGON, 4326)")
+    private Polygon jailPolygon;
+
     public static GameResult createSnapshot(
             Game game,
             Team winningTeam,
@@ -101,10 +109,13 @@ public class GameResult extends BaseTimeEntity {
 
         if (gameArea.getAreaType() == AreaType.CIRCLE) {
             builder.playgroundCenter(gameArea.getPlaygroundCenter())
-                   .playgroundRadiusInMeters(gameArea.getPlaygroundRadiusInMeters());
+                   .playgroundRadiusInMeters(gameArea.getPlaygroundRadiusInMeters())
+                   .jailCenter(gameArea.getJailCenter())
+                   .jailRadiusInMeters(gameArea.getJailRadiusInMeters());
         }
         else {
-            builder.playgroundPolygon(gameArea.getPlaygroundPolygon());
+            builder.playgroundPolygon(gameArea.getPlaygroundPolygon())
+                   .jailPolygon(gameArea.getJailPolygon());
         }
 
         return builder.build();

--- a/src/main/java/com/team/cops_and_robbers/history/repository/GameResultRepository.java
+++ b/src/main/java/com/team/cops_and_robbers/history/repository/GameResultRepository.java
@@ -1,8 +1,10 @@
 package com.team.cops_and_robbers.history.repository;
 
+import com.team.cops_and_robbers.common.exception.ApplicationException;
 import com.team.cops_and_robbers.game.participant.domain.Team;
 import com.team.cops_and_robbers.history.domain.GameEndReason;
 import com.team.cops_and_robbers.history.domain.GameResult;
+import com.team.cops_and_robbers.history.exception.GameResultException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -34,4 +36,9 @@ public interface GameResultRepository extends JpaRepository<GameResult, Long> {
             @Param("endReason") GameEndReason endReason,
             Pageable pageable
     );
+
+    default GameResult getByGameResultId(Long gameResultId) {
+        return findById(gameResultId)
+                .orElseThrow(() -> new ApplicationException(GameResultException.GAME_RESULT_NOT_FOUND));
+    }
 }

--- a/src/main/resources/db/migration/V260815_1000__add_jail_to_game_results.sql
+++ b/src/main/resources/db/migration/V260815_1000__add_jail_to_game_results.sql
@@ -1,0 +1,4 @@
+ALTER TABLE game_results
+    ADD COLUMN jail_center           GEOMETRY(POINT, 4326),
+    ADD COLUMN jail_radius_in_meters INTEGER,
+    ADD COLUMN jail_polygon          GEOMETRY(POLYGON, 4326);

--- a/src/main/resources/graphql/game.graphqls
+++ b/src/main/resources/graphql/game.graphqls
@@ -15,6 +15,8 @@ extend type Query {
     endReason: GameEndReason
     sortDirection: SortDirection = DESC
   ): AdminGameHistoryPage!
+
+  adminGameHistory(id: ID!): AdminGameHistory!
 }
 
 # ─── 게임 타입 ───────────────────────────────────────────────

--- a/src/main/resources/graphql/game.graphqls
+++ b/src/main/resources/graphql/game.graphqls
@@ -108,6 +108,7 @@ type AdminGameHistory {
   totalArrestCount: Int!
   durationSeconds: Int!
   areaType: AreaType!
+  area: GameArea
   createdAt: String!
   participants: [AdminGameHistoryParticipant!]!
 }

--- a/src/test/java/com/team/cops_and_robbers/admin/application/AdminGameHistoryServiceTest.java
+++ b/src/test/java/com/team/cops_and_robbers/admin/application/AdminGameHistoryServiceTest.java
@@ -2,12 +2,14 @@ package com.team.cops_and_robbers.admin.application;
 
 import com.team.cops_and_robbers.admin.application.dto.SortDirection;
 import com.team.cops_and_robbers.admin.application.dto.command.game.AdminGameHistoryListCommand;
+import com.team.cops_and_robbers.admin.application.dto.result.game.AdminGameAreaResult;
 import com.team.cops_and_robbers.admin.application.dto.result.game.AdminGameHistoryPageResult;
 import com.team.cops_and_robbers.admin.application.dto.result.game.AdminGameHistoryParticipantResult;
 import com.team.cops_and_robbers.admin.application.dto.result.game.AdminGameHistoryResult;
 import com.team.cops_and_robbers.common.ServiceUnitTest;
 import com.team.cops_and_robbers.common.fixture.GameResultFixture;
 import com.team.cops_and_robbers.common.fixture.GameResultParticipantFixture;
+import com.team.cops_and_robbers.game.area.domain.AreaType;
 import com.team.cops_and_robbers.game.participant.domain.Team;
 import com.team.cops_and_robbers.history.domain.GameEndReason;
 import com.team.cops_and_robbers.history.domain.GameResult;
@@ -39,7 +41,10 @@ class AdminGameHistoryServiceTest extends ServiceUnitTest {
     private AdminGameHistoryService adminGameHistoryService;
 
     private GameResult createGameResult(Long gameId, Long id) {
-        GameResult gameResult = GameResultFixture.POLICE_WIN_RESULT(gameId);
+        return prepare(GameResultFixture.POLICE_WIN_RESULT(gameId), id);
+    }
+
+    private GameResult prepare(GameResult gameResult, Long id) {
         setId(gameResult, id);
         org.springframework.test.util.ReflectionTestUtils.setField(gameResult, "createdAt", FIXED_TIME);
         return gameResult;
@@ -94,6 +99,76 @@ class AdminGameHistoryServiceTest extends ServiceUnitTest {
                 softly.assertThat(result.content().get(0).endReason())
                         .isEqualTo(GameEndReason.ALL_ARRESTED);
             });
+        }
+
+        @Test
+        void 원형_구역_기록이면_area에_중심_좌표와_반경이_매핑된다() {
+            // given
+            AdminGameHistoryListCommand command = new AdminGameHistoryListCommand(
+                    0, 10, null, SortDirection.DESC);
+
+            GameResult circleResult = createGameResult(1L, 10L);
+            Page<GameResult> resultPage = new PageImpl<>(
+                    List.of(circleResult), PageRequest.of(0, 10), 1);
+            given(gameResultRepository.findAllForAdmin(isNull(), any())).willReturn(resultPage);
+
+            // when
+            AdminGameHistoryPageResult result = adminGameHistoryService.getGameHistoryList(command);
+
+            // then
+            AdminGameAreaResult area = result.content().get(0).area();
+            assertSoftly(softly -> {
+                softly.assertThat(area.areaType()).isEqualTo(AreaType.CIRCLE);
+                softly.assertThat(area.playgroundCenterLat()).isEqualTo(37.4979);
+                softly.assertThat(area.playgroundCenterLng()).isEqualTo(127.0276);
+                softly.assertThat(area.playgroundRadiusInMeters()).isEqualTo(500);
+                softly.assertThat(area.jailCenterLat()).isNull();
+                softly.assertThat(area.playgroundPolygon()).isNull();
+            });
+        }
+
+        @Test
+        void 다각형_구역_기록이면_area에_폴리곤_좌표가_매핑된다() {
+            // given
+            AdminGameHistoryListCommand command = new AdminGameHistoryListCommand(
+                    0, 10, null, SortDirection.DESC);
+
+            GameResult polygonResult = prepare(GameResultFixture.POLICE_WIN_RESULT_POLYGON(1L), 10L);
+            Page<GameResult> resultPage = new PageImpl<>(
+                    List.of(polygonResult), PageRequest.of(0, 10), 1);
+            given(gameResultRepository.findAllForAdmin(isNull(), any())).willReturn(resultPage);
+
+            // when
+            AdminGameHistoryPageResult result = adminGameHistoryService.getGameHistoryList(command);
+
+            // then
+            AdminGameAreaResult area = result.content().get(0).area();
+            assertSoftly(softly -> {
+                softly.assertThat(area.areaType()).isEqualTo(AreaType.POLYGON);
+                softly.assertThat(area.playgroundPolygon()).hasSize(4);
+                softly.assertThat(area.playgroundPolygon().get(0).latitude()).isEqualTo(37.4979);
+                softly.assertThat(area.playgroundPolygon().get(0).longitude()).isEqualTo(127.0276);
+                softly.assertThat(area.playgroundCenterLat()).isNull();
+                softly.assertThat(area.jailPolygon()).isNull();
+            });
+        }
+
+        @Test
+        void 좌표가_없는_과거_기록이면_area가_null이다() {
+            // given
+            AdminGameHistoryListCommand command = new AdminGameHistoryListCommand(
+                    0, 10, null, SortDirection.DESC);
+
+            GameResult legacyResult = prepare(GameResultFixture.LEGACY_RESULT_WITHOUT_AREA(1L), 10L);
+            Page<GameResult> resultPage = new PageImpl<>(
+                    List.of(legacyResult), PageRequest.of(0, 10), 1);
+            given(gameResultRepository.findAllForAdmin(isNull(), any())).willReturn(resultPage);
+
+            // when
+            AdminGameHistoryPageResult result = adminGameHistoryService.getGameHistoryList(command);
+
+            // then
+            assertThat(result.content().get(0).area()).isNull();
         }
 
         @Test

--- a/src/test/java/com/team/cops_and_robbers/admin/application/AdminGameHistoryServiceTest.java
+++ b/src/test/java/com/team/cops_and_robbers/admin/application/AdminGameHistoryServiceTest.java
@@ -7,6 +7,7 @@ import com.team.cops_and_robbers.admin.application.dto.result.game.AdminGameHist
 import com.team.cops_and_robbers.admin.application.dto.result.game.AdminGameHistoryParticipantResult;
 import com.team.cops_and_robbers.admin.application.dto.result.game.AdminGameHistoryResult;
 import com.team.cops_and_robbers.common.ServiceUnitTest;
+import com.team.cops_and_robbers.common.exception.ApplicationException;
 import com.team.cops_and_robbers.common.fixture.GameResultFixture;
 import com.team.cops_and_robbers.common.fixture.GameResultParticipantFixture;
 import com.team.cops_and_robbers.game.area.domain.AreaType;
@@ -14,6 +15,7 @@ import com.team.cops_and_robbers.game.participant.domain.Team;
 import com.team.cops_and_robbers.history.domain.GameEndReason;
 import com.team.cops_and_robbers.history.domain.GameResult;
 import com.team.cops_and_robbers.history.domain.GameResultParticipant;
+import com.team.cops_and_robbers.history.exception.GameResultException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -26,6 +28,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.mockito.BDDMockito.given;
@@ -122,7 +125,9 @@ class AdminGameHistoryServiceTest extends ServiceUnitTest {
                 softly.assertThat(area.playgroundCenterLat()).isEqualTo(37.4979);
                 softly.assertThat(area.playgroundCenterLng()).isEqualTo(127.0276);
                 softly.assertThat(area.playgroundRadiusInMeters()).isEqualTo(500);
-                softly.assertThat(area.jailCenterLat()).isNull();
+                softly.assertThat(area.jailCenterLat()).isEqualTo(37.4989);
+                softly.assertThat(area.jailCenterLng()).isEqualTo(127.0286);
+                softly.assertThat(area.jailRadiusInMeters()).isEqualTo(50);
                 softly.assertThat(area.playgroundPolygon()).isNull();
             });
         }
@@ -149,7 +154,33 @@ class AdminGameHistoryServiceTest extends ServiceUnitTest {
                 softly.assertThat(area.playgroundPolygon().get(0).latitude()).isEqualTo(37.4979);
                 softly.assertThat(area.playgroundPolygon().get(0).longitude()).isEqualTo(127.0276);
                 softly.assertThat(area.playgroundCenterLat()).isNull();
-                softly.assertThat(area.jailPolygon()).isNull();
+                softly.assertThat(area.jailPolygon()).hasSize(4);
+                softly.assertThat(area.jailPolygon().get(0).latitude()).isEqualTo(37.4983);
+                softly.assertThat(area.jailPolygon().get(0).longitude()).isEqualTo(127.0280);
+            });
+        }
+
+        @Test
+        void 감옥_좌표가_없는_기록은_jail_필드만_null이다() {
+            // given
+            AdminGameHistoryListCommand command = new AdminGameHistoryListCommand(
+                    0, 10, null, SortDirection.DESC);
+
+            GameResult withoutJailResult = prepare(GameResultFixture.POLICE_WIN_RESULT_WITHOUT_JAIL(1L), 10L);
+            Page<GameResult> resultPage = new PageImpl<>(
+                    List.of(withoutJailResult), PageRequest.of(0, 10), 1);
+            given(gameResultRepository.findAllForAdmin(isNull(), any())).willReturn(resultPage);
+
+            // when
+            AdminGameHistoryPageResult result = adminGameHistoryService.getGameHistoryList(command);
+
+            // then
+            AdminGameAreaResult area = result.content().get(0).area();
+            assertSoftly(softly -> {
+                softly.assertThat(area.playgroundCenterLat()).isEqualTo(37.4979);
+                softly.assertThat(area.jailCenterLat()).isNull();
+                softly.assertThat(area.jailCenterLng()).isNull();
+                softly.assertThat(area.jailRadiusInMeters()).isNull();
             });
         }
 
@@ -189,6 +220,40 @@ class AdminGameHistoryServiceTest extends ServiceUnitTest {
                 softly.assertThat(result.totalElements()).isZero();
                 softly.assertThat(result.content()).isEmpty();
             });
+        }
+    }
+
+    @Nested
+    @DisplayName("게임 히스토리 단건 조회")
+    class GetGameHistory {
+
+        @Test
+        void 히스토리_단건을_조회하면_구역_정보를_포함해_반환한다() {
+            // given
+            GameResult gameResult = createGameResult(1L, 10L);
+            given(gameResultRepository.getByGameResultId(10L)).willReturn(gameResult);
+
+            // when
+            AdminGameHistoryResult result = adminGameHistoryService.getGameHistory(10L);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(result.id()).isEqualTo(10L);
+                softly.assertThat(result.gameId()).isEqualTo(1L);
+                softly.assertThat(result.area()).isNotNull();
+            });
+        }
+
+        @Test
+        void 존재하지_않는_히스토리를_조회하면_GAME_RESULT_NOT_FOUND_예외가_발생한다() {
+            // given
+            given(gameResultRepository.getByGameResultId(999L))
+                    .willThrow(new ApplicationException(GameResultException.GAME_RESULT_NOT_FOUND));
+
+            // when & then
+            assertThatThrownBy(() -> adminGameHistoryService.getGameHistory(999L))
+                    .isInstanceOf(ApplicationException.class)
+                    .hasMessageContaining(GameResultException.GAME_RESULT_NOT_FOUND.getDetail());
         }
     }
 

--- a/src/test/java/com/team/cops_and_robbers/common/fixture/GameResultFixture.java
+++ b/src/test/java/com/team/cops_and_robbers/common/fixture/GameResultFixture.java
@@ -51,6 +51,20 @@ public class GameResultFixture {
                 .build();
     }
 
+    public static GameResult LEGACY_RESULT_WITHOUT_AREA(Long gameId) {
+        return GameResult.builder()
+                .gameId(gameId)
+                .winnerTeam(Team.POLICE)
+                .endReason(GameEndReason.ALL_ARRESTED)
+                .totalPoliceCount(2)
+                .totalRobberCount(3)
+                .arrestedRobberCount(3)
+                .totalArrestCount(5)
+                .durationSeconds(300)
+                .areaType(AreaType.CIRCLE)
+                .build();
+    }
+
     private static Polygon createPolygon(double[][] coords) {
         Coordinate[] coordinates = new Coordinate[coords.length + 1];
         for (int i = 0; i < coords.length; i++) {

--- a/src/test/java/com/team/cops_and_robbers/common/fixture/GameResultFixture.java
+++ b/src/test/java/com/team/cops_and_robbers/common/fixture/GameResultFixture.java
@@ -17,6 +17,26 @@ public class GameResultFixture {
 
     public static GameResult POLICE_WIN_RESULT(Long gameId) {
         Point center = GEOMETRY_FACTORY.createPoint(new Coordinate(127.0276, 37.4979));
+        Point jailCenter = GEOMETRY_FACTORY.createPoint(new Coordinate(127.0286, 37.4989));
+        return GameResult.builder()
+                .gameId(gameId)
+                .winnerTeam(Team.POLICE)
+                .endReason(GameEndReason.ALL_ARRESTED)
+                .totalPoliceCount(2)
+                .totalRobberCount(3)
+                .arrestedRobberCount(3)
+                .totalArrestCount(5)
+                .durationSeconds(300)
+                .areaType(AreaType.CIRCLE)
+                .playgroundCenter(center)
+                .playgroundRadiusInMeters(500)
+                .jailCenter(jailCenter)
+                .jailRadiusInMeters(50)
+                .build();
+    }
+
+    public static GameResult POLICE_WIN_RESULT_WITHOUT_JAIL(Long gameId) {
+        Point center = GEOMETRY_FACTORY.createPoint(new Coordinate(127.0276, 37.4979));
         return GameResult.builder()
                 .gameId(gameId)
                 .winnerTeam(Team.POLICE)
@@ -37,6 +57,10 @@ public class GameResultFixture {
                 {127.0276, 37.4979}, {127.0296, 37.4979},
                 {127.0296, 37.4999}, {127.0276, 37.4999}
         });
+        Polygon jailPolygon = createPolygon(new double[][]{
+                {127.0280, 37.4983}, {127.0285, 37.4983},
+                {127.0285, 37.4988}, {127.0280, 37.4988}
+        });
         return GameResult.builder()
                 .gameId(gameId)
                 .winnerTeam(Team.POLICE)
@@ -48,6 +72,7 @@ public class GameResultFixture {
                 .durationSeconds(300)
                 .areaType(AreaType.POLYGON)
                 .playgroundPolygon(polygon)
+                .jailPolygon(jailPolygon)
                 .build();
     }
 

--- a/src/test/java/com/team/cops_and_robbers/history/application/GameResultServiceTest.java
+++ b/src/test/java/com/team/cops_and_robbers/history/application/GameResultServiceTest.java
@@ -71,6 +71,50 @@ class GameResultServiceTest extends ServiceUnitTest {
         }
 
         @Test
+        void CIRCLE_영역_게임이_종료되면_감옥_중심과_반경도_저장된다() {
+            // given
+            Game game = IN_PROGRESS_GAME();
+            setId(game, TEST_GAME_ID);
+            GameArea circleArea = CIRCLE_GAME_AREA(game);
+
+            given(gameAreaRepository.getByGameId(TEST_GAME_ID)).willReturn(circleArea);
+            given(gameParticipantRepository.countByGameIdAndTeam(TEST_GAME_ID, Team.POLICE)).willReturn(2);
+            given(gameParticipantRepository.countByGameIdAndTeam(TEST_GAME_ID, Team.ROBBER)).willReturn(3);
+            given(gameParticipantRepository.countByGameIdAndRobberStatus(TEST_GAME_ID, ParticipantStatus.JAILED)).willReturn(3);
+            given(gameResultRepository.save(any(GameResult.class))).willAnswer(inv -> inv.getArgument(0));
+
+            // when
+            GameResult result = gameResultService.recordGameResult(game, Team.POLICE, GameEndReason.ALL_ARRESTED);
+
+            // then
+            assertThat(result.getJailCenter()).isEqualTo(circleArea.getJailCenter());
+            assertThat(result.getJailRadiusInMeters()).isEqualTo(circleArea.getJailRadiusInMeters());
+            assertThat(result.getJailPolygon()).isNull();
+        }
+
+        @Test
+        void POLYGON_영역_게임이_종료되면_감옥_폴리곤도_저장된다() {
+            // given
+            Game game = IN_PROGRESS_GAME();
+            setId(game, TEST_GAME_ID);
+            GameArea polygonArea = POLYGON_GAME_AREA(game);
+
+            given(gameAreaRepository.getByGameId(TEST_GAME_ID)).willReturn(polygonArea);
+            given(gameParticipantRepository.countByGameIdAndTeam(TEST_GAME_ID, Team.POLICE)).willReturn(2);
+            given(gameParticipantRepository.countByGameIdAndTeam(TEST_GAME_ID, Team.ROBBER)).willReturn(3);
+            given(gameParticipantRepository.countByGameIdAndRobberStatus(TEST_GAME_ID, ParticipantStatus.JAILED)).willReturn(3);
+            given(gameResultRepository.save(any(GameResult.class))).willAnswer(inv -> inv.getArgument(0));
+
+            // when
+            GameResult result = gameResultService.recordGameResult(game, Team.POLICE, GameEndReason.ALL_ARRESTED);
+
+            // then
+            assertThat(result.getJailPolygon()).isEqualTo(polygonArea.getJailPolygon());
+            assertThat(result.getJailCenter()).isNull();
+            assertThat(result.getJailRadiusInMeters()).isNull();
+        }
+
+        @Test
         void POLYGON_영역_게임이_종료되면_polygon_필드가_채워진_결과가_저장된다() {
             // given
             Game game = IN_PROGRESS_GAME();


### PR DESCRIPTION
## 📎 Issue 번호
- 없음 (어드민 프론트 요청 반영)

## ✨ 작업 내용
어드민 지난 게임 기록(adminGameHistories)에 플레이 구역 좌표(`area`)를 노출합니다.

- `AdminGameHistory`에 `area: GameArea` 필드 추가 — `adminGame.area`와 같은 타입이라 프론트 지도 컴포넌트를 그대로 쓸 수 있습니다
- 원형은 중심 좌표·반경, 다각형은 폴리곤 좌표 매핑
- 좌표가 없는 과거 기록은 `area = null`

## 📝 기타
- 좌표는 게임 종료 시 `GameResult`에 이미 저장되고 있어, 저장 변경 없이 노출만 추가했습니다 (추가 쿼리 없음)

## ✅ 테스트
- [X] 수동 테스트 완료
- [x] 테스트 코드 완료
